### PR TITLE
Publish to S3 repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,10 @@
 name: Publish OSS Builds to S3
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: false
 
 jobs:
   publish:
@@ -23,10 +28,12 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Set CONDUCTOR_VERSION
+        run: export CONDUCTOR_VERSION = ${{ github.event.inputs.version }}
       - name: Publish snapshot build
         run:  |
           ./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}'
-          echo "conductor version is $CONDUCTOR_VERSION"
+          echo "\nCONDUCTOR_VERSION env var is '$CONDUCTOR_VERSION'\n"
           ./gradlew publish -x test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,17 +32,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Publish snapshot build
+      - name: Publish artifacts
         run:  |
           export CONDUCTOR_VERSION='${{ github.event.inputs.version }}'
           ./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{print "version:", $2}'
           ./gradlew publish -x test
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Publish release
-        if: startsWith(github.ref, 'refs/tags/v') && (!contains(github.ref, '-rc.'))
-        run: ./gradlew publish -x test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,18 +2,22 @@ name: Publish OSS Builds to S3
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Tag or branch to checkout'
+        required: true
       version:
         description: 'Version to publish'
-        required: false
+        required: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    name: Gradle Build and Publish
+    name: Publish OSS Builds to S3
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
       - name: Set up Zulu JDK 11
         uses: actions/setup-java@v2
         with:
@@ -28,12 +32,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Set CONDUCTOR_VERSION
-        run: export CONDUCTOR_VERSION = ${{ github.event.inputs.version }}
       - name: Publish snapshot build
         run:  |
-          ./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}'
-          echo "\nCONDUCTOR_VERSION env var is '$CONDUCTOR_VERSION'\n"
+          export CONDUCTOR_VERSION='${{ github.event.inputs.version }}'
+          ./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{print "version:", $2}'
           ./gradlew publish -x test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ jobs:
     name: Gradle Build and Publish
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Zulu JDK 11
         uses: actions/setup-java@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_11
 
     group = 'com.netflix.conductor'
+    if (System.getenv('CONDUCTOR_VERSION')) {
+        version = System.getenv('CONDUCTOR_VERSION')
+        println "Inferred version from env variable 'CONDUCTOR_VERSION': $version"
+    }
 
     configurations.all {
         exclude group: 'ch.qos.logback', module: 'logback-classic'

--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,10 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_11
 
     group = 'com.netflix.conductor'
-    if (System.getenv('CONDUCTOR_VERSION')) {
-        version = System.getenv('CONDUCTOR_VERSION')
-        println "Inferred version from env variable 'CONDUCTOR_VERSION': $version"
+    def conductorVersion = System.getenv('CONDUCTOR_VERSION')
+    if (conductorVersion) {
+        println "Inferred version from env variable 'CONDUCTOR_VERSION': $conductorVersion"
+        version =  conductorVersion
     }
 
     configurations.all {


### PR DESCRIPTION
- The version (inferred by Nebula publishing plugin) can be overriden by `CONDUCTOR_VERSION` env variable.
- A tag or branch is checked out and used to publish.
- The version of the artifacts is entered manually for greater flexibility and the rule of least surprise (this can be adjusted once we have a solid versioning convention. Not prefixing `orkes-`, inferring it from the tag or anything)