### PR TITLE
Initial changes to support password auth with redis_sentinel

### DIFF
--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisSentinelConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisSentinelConfiguration.java
@@ -13,6 +13,7 @@
 package com.netflix.conductor.redis.config;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -28,6 +29,7 @@ import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
 
 import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.commands.JedisCommands;
 
 @Configuration(proxyBeanMethods = false)
@@ -59,8 +61,31 @@ public class RedisSentinelConfiguration extends JedisCommandsConfigurer {
         for (Host host : hostSupplier.getHosts()) {
             sentinels.add(host.getHostName() + ":" + host.getPort());
         }
-        return new JedisSentinel(
-                new JedisSentinelPool(
-                        properties.getClusterName(), sentinels, genericObjectPoolConfig));
+        // We use the password of the first sentinel host as password and sentinelPassword
+        String password = getPassword(hostSupplier.getHosts());
+        if (password != null) {
+            return new JedisSentinel(
+                    new JedisSentinelPool(
+                            properties.getClusterName(),
+                            sentinels,
+                            genericObjectPoolConfig,
+                            Protocol.DEFAULT_TIMEOUT,
+                            Protocol.DEFAULT_TIMEOUT,
+                            password,
+                            Protocol.DEFAULT_DATABASE,
+                            null,
+                            Protocol.DEFAULT_TIMEOUT,
+                            Protocol.DEFAULT_TIMEOUT,
+                            password,
+                            null));
+        } else {
+            return new JedisSentinel(
+                    new JedisSentinelPool(
+                            properties.getClusterName(), sentinels, genericObjectPoolConfig));
+        }
+    }
+
+    private String getPassword(List<Host> hosts) {
+        return !hosts.isEmpty() ? hosts.get(0).getPassword() : null;
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Added support for password authentication with Redis Sentinel.

**NOTES**
The password is taken from host[0].

Assuming sentinels and redis nodes use the same password.

![image](https://user-images.githubusercontent.com/4755315/158882748-a98c3bc9-3d90-4c9b-832b-4dd14f1f4af7.png)
