### PR TITLE
Add and persist `createdBy` when a Workflow is started

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/StartWorkflowRequest.java
@@ -54,6 +54,9 @@ public class StartWorkflowRequest {
     @Max(value = 99, message = "priority: ${validatedValue} should be maximum {value}")
     private Integer priority = 0;
 
+    @ProtoField(id = 9)
+    private String createdBy;
+
     public String getName() {
         return name;
     }
@@ -156,6 +159,19 @@ public class StartWorkflowRequest {
 
     public StartWorkflowRequest withWorkflowDef(WorkflowDef workflowDef) {
         this.workflowDef = workflowDef;
+        return this;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public StartWorkflowRequest withCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
         return this;
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -83,6 +83,9 @@ public class WorkflowSummary {
     @ProtoField(id = 17)
     private int priority;
 
+    @ProtoField(id = 18)
+    private String createdBy;
+
     public WorkflowSummary() {}
 
     public WorkflowSummary(Workflow workflow) {
@@ -124,6 +127,8 @@ public class WorkflowSummary {
         if (StringUtils.isNotBlank(workflow.getExternalOutputPayloadStoragePath())) {
             this.externalOutputPayloadStoragePath = workflow.getExternalOutputPayloadStoragePath();
         }
+
+        this.createdBy = workflow.getCreatedBy();
     }
 
     /**
@@ -332,6 +337,14 @@ public class WorkflowSummary {
         this.priority = priority;
     }
 
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -352,7 +365,8 @@ public class WorkflowSummary {
                 && StringUtils.equals(getEndTime(), that.getEndTime())
                 && getStatus() == that.getStatus()
                 && Objects.equals(getReasonForIncompletion(), that.getReasonForIncompletion())
-                && Objects.equals(getEvent(), that.getEvent());
+                && Objects.equals(getEvent(), that.getEvent())
+                && Objects.equals(getCreatedBy(), that.getCreatedBy());
     }
 
     @Override
@@ -369,6 +383,7 @@ public class WorkflowSummary {
                 getReasonForIncompletion(),
                 getExecutionTime(),
                 getEvent(),
-                getPriority());
+                getPriority(),
+                getCreatedBy());
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -250,6 +250,33 @@ public class WorkflowExecutor {
     public String startWorkflow(
             String name,
             Integer version,
+            String correlationId,
+            Integer priority,
+            Map<String, Object> input,
+            String externalInputPayloadStoragePath,
+            String event,
+            Map<String, String> taskToDomain,
+            String createdBy) {
+        return startWorkflow(
+                name,
+                version,
+                input,
+                externalInputPayloadStoragePath,
+                correlationId,
+                priority,
+                null,
+                null,
+                event,
+                taskToDomain,
+                createdBy);
+    }
+
+    /**
+     * @throws ApplicationException
+     */
+    public String startWorkflow(
+            String name,
+            Integer version,
             Map<String, Object> input,
             String externalInputPayloadStoragePath,
             String correlationId,
@@ -315,6 +342,31 @@ public class WorkflowExecutor {
      * @throws ApplicationException
      */
     public String startWorkflow(
+            WorkflowDef workflowDefinition,
+            Map<String, Object> workflowInput,
+            String externalInputPayloadStoragePath,
+            String correlationId,
+            Integer priority,
+            String event,
+            Map<String, String> taskToDomain,
+            String createdBy) {
+        return startWorkflow(
+                workflowDefinition,
+                workflowInput,
+                externalInputPayloadStoragePath,
+                correlationId,
+                priority,
+                null,
+                null,
+                event,
+                taskToDomain,
+                createdBy);
+    }
+
+    /**
+     * @throws ApplicationException
+     */
+    public String startWorkflow(
             String name,
             Integer version,
             Map<String, Object> workflowInput,
@@ -367,6 +419,37 @@ public class WorkflowExecutor {
     }
 
     /**
+     * @throws ApplicationException
+     */
+    public String startWorkflow(
+            String name,
+            Integer version,
+            Map<String, Object> workflowInput,
+            String externalInputPayloadStoragePath,
+            String correlationId,
+            Integer priority,
+            String parentWorkflowId,
+            String parentWorkflowTaskId,
+            String event,
+            Map<String, String> taskToDomain,
+            String createdBy) {
+        WorkflowDef workflowDefinition =
+                metadataMapperService.lookupForWorkflowDefinition(name, version);
+
+        return startWorkflow(
+                workflowDefinition,
+                workflowInput,
+                externalInputPayloadStoragePath,
+                correlationId,
+                priority,
+                parentWorkflowId,
+                parentWorkflowTaskId,
+                event,
+                taskToDomain,
+                createdBy);
+    }
+
+    /**
      * @throws ApplicationException if validation fails
      */
     public String startWorkflow(
@@ -379,6 +462,33 @@ public class WorkflowExecutor {
             String parentWorkflowTaskId,
             String event,
             Map<String, String> taskToDomain) {
+        return startWorkflow(
+                workflowDefinition,
+                workflowInput,
+                externalInputPayloadStoragePath,
+                correlationId,
+                priority,
+                parentWorkflowId,
+                parentWorkflowTaskId,
+                event,
+                taskToDomain,
+                null);
+    }
+
+    /**
+     * @throws ApplicationException if validation fails
+     */
+    public String startWorkflow(
+            WorkflowDef workflowDefinition,
+            Map<String, Object> workflowInput,
+            String externalInputPayloadStoragePath,
+            String correlationId,
+            Integer priority,
+            String parentWorkflowId,
+            String parentWorkflowTaskId,
+            String event,
+            Map<String, String> taskToDomain,
+            String createdBy) {
 
         workflowDefinition = metadataMapperService.populateTaskDefinitions(workflowDefinition);
 
@@ -399,6 +509,7 @@ public class WorkflowExecutor {
         workflow.setParentWorkflowTaskId(parentWorkflowTaskId);
         workflow.setOwnerApp(WorkflowContext.get().getClientApp());
         workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreatedBy(createdBy);
         workflow.setUpdatedBy(null);
         workflow.setUpdatedTime(null);
         workflow.setEvent(event);

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -71,7 +71,8 @@ public class WorkflowServiceImpl implements WorkflowService {
                 startWorkflowRequest.getInput(),
                 startWorkflowRequest.getExternalInputPayloadStoragePath(),
                 startWorkflowRequest.getTaskToDomain(),
-                startWorkflowRequest.getWorkflowDef());
+                startWorkflowRequest.getWorkflowDef(),
+                startWorkflowRequest.getCreatedBy());
     }
 
     /**
@@ -149,6 +150,63 @@ public class WorkflowServiceImpl implements WorkflowService {
                     priority,
                     null,
                     taskToDomain);
+        }
+    }
+
+    /**
+     * Start a new workflow with StartWorkflowRequest, which allows task to be executed in a domain.
+     *
+     * @param name Name of the workflow you want to start.
+     * @param version Version of the workflow you want to start.
+     * @param correlationId CorrelationID of the workflow you want to start.
+     * @param priority Priority of the workflow you want to start.
+     * @param input Input to the workflow you want to start.
+     * @param externalInputPayloadStoragePath the relative path in external storage where input *
+     *     payload is located
+     * @param taskToDomain the task to domain mapping
+     * @param workflowDef - workflow definition
+     * @param createdBy Id or email of the user that started the Workflow.
+     * @return the id of the workflow instance that can be use for tracking.
+     */
+    public String startWorkflow(
+            String name,
+            Integer version,
+            String correlationId,
+            Integer priority,
+            Map<String, Object> input,
+            String externalInputPayloadStoragePath,
+            Map<String, String> taskToDomain,
+            WorkflowDef workflowDef,
+            String createdBy) {
+        if (workflowDef == null) {
+            workflowDef = metadataService.getWorkflowDef(name, version);
+            if (workflowDef == null) {
+                throw new ApplicationException(
+                        ApplicationException.Code.NOT_FOUND,
+                        String.format(
+                                "No such workflow found by name: %s, version: %d", name, version));
+            }
+
+            return workflowExecutor.startWorkflow(
+                    name,
+                    version,
+                    correlationId,
+                    priority,
+                    input,
+                    externalInputPayloadStoragePath,
+                    null,
+                    taskToDomain,
+                    createdBy);
+        } else {
+            return workflowExecutor.startWorkflow(
+                    workflowDef,
+                    input,
+                    externalInputPayloadStoragePath,
+                    correlationId,
+                    priority,
+                    null,
+                    taskToDomain,
+                    createdBy);
         }
     }
 

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -41,13 +41,7 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import static com.netflix.conductor.TestUtils.getConstraintViolationMessages;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -128,6 +122,7 @@ public class WorkflowServiceTest {
         StartWorkflowRequest startWorkflowRequest = new StartWorkflowRequest();
         startWorkflowRequest.setName("test");
         startWorkflowRequest.setVersion(1);
+        startWorkflowRequest.setCreatedBy("junit@test.org");
 
         Map<String, Object> input = new HashMap<>();
         input.put("1", "abc");
@@ -136,14 +131,15 @@ public class WorkflowServiceTest {
 
         when(metadataService.getWorkflowDef("test", 1)).thenReturn(workflowDef);
         when(workflowExecutor.startWorkflow(
-                        anyString(),
-                        anyInt(),
+                        eq("test"),
+                        eq(1),
                         isNull(),
                         anyInt(),
                         anyMap(),
                         isNull(),
                         isNull(),
-                        anyMap()))
+                        anyMap(),
+                        eq("junit@test.org")))
                 .thenReturn(workflowID);
         assertEquals("w112", workflowService.startWorkflow(startWorkflowRequest));
     }

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -437,6 +437,9 @@ public abstract class AbstractProtoMapper {
         if (from.getPriority() != null) {
             to.setPriority( from.getPriority() );
         }
+        if (from.getCreatedBy() != null) {
+            to.setCreatedBy( from.getCreatedBy() );
+        }
         return to.build();
     }
 
@@ -456,6 +459,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
         to.setPriority( from.getPriority() );
+        to.setCreatedBy( from.getCreatedBy() );
         return to;
     }
 
@@ -1218,6 +1222,9 @@ public abstract class AbstractProtoMapper {
             to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         }
         to.setPriority( from.getPriority() );
+        if (from.getCreatedBy() != null) {
+            to.setCreatedBy( from.getCreatedBy() );
+        }
         return to.build();
     }
 
@@ -1240,6 +1247,7 @@ public abstract class AbstractProtoMapper {
         to.setExternalInputPayloadStoragePath( from.getExternalInputPayloadStoragePath() );
         to.setExternalOutputPayloadStoragePath( from.getExternalOutputPayloadStoragePath() );
         to.setPriority( from.getPriority() );
+        to.setCreatedBy( from.getCreatedBy() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/startworkflowrequest.proto
+++ b/grpc/src/main/proto/model/startworkflowrequest.proto
@@ -17,4 +17,5 @@ message StartWorkflowRequest {
     WorkflowDef workflow_def = 6;
     string external_input_payload_storage_path = 7;
     int32 priority = 8;
+    string created_by = 9;
 }

--- a/grpc/src/main/proto/model/workflowsummary.proto
+++ b/grpc/src/main/proto/model/workflowsummary.proto
@@ -25,4 +25,5 @@ message WorkflowSummary {
     string external_input_payload_storage_path = 15;
     string external_output_payload_storage_path = 16;
     int32 priority = 17;
+    string created_by = 18;
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- Added `createdBy` property to `StartWorkflowRequest` and `WorkflowSummary` (`WorkflowModel` already has this property).
- When making a request to start a workflow `createdBy` can be set to the id or email of the user that started the Workflow. 
- If there's a security layer the request value could be ignored or overridden and set to the id or email of the user making the request.