### PR TITLE
NOTASK - make Conductor use String instead of TaskType when setting up TaskMappers

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorCoreConfiguration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorCoreConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
-import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.events.EventQueueProvider;
 import com.netflix.conductor.core.execution.mapper.TaskMapper;
@@ -98,8 +97,9 @@ public class ConductorCoreConfiguration {
 
     @Bean
     @Qualifier("taskMappersByTaskType")
-    public Map<TaskType, TaskMapper> getTaskMappers(List<TaskMapper> taskMappers) {
-        return taskMappers.stream().collect(Collectors.toMap(TaskMapper::getTaskType, identity()));
+    public Map<String, TaskMapper> getTaskMappers(List<TaskMapper> taskMappers) {
+        return taskMappers.stream()
+                .collect(Collectors.toMap(t -> t.getTaskType().name(), identity()));
     }
 
     @Bean

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -44,6 +44,7 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TERMINATE;
+import static com.netflix.conductor.common.metadata.tasks.TaskType.USER_DEFINED;
 import static com.netflix.conductor.model.TaskModel.Status.*;
 
 /**
@@ -63,7 +64,7 @@ public class DeciderService {
     private final SystemTaskRegistry systemTaskRegistry;
     private final long taskPendingTimeThresholdMins;
 
-    private final Map<TaskType, TaskMapper> taskMappers;
+    private final Map<String, TaskMapper> taskMappers;
 
     public DeciderService(
             IDGenerator idGenerator,
@@ -71,7 +72,7 @@ public class DeciderService {
             MetadataDAO metadataDAO,
             ExternalPayloadStorageUtils externalPayloadStorageUtils,
             SystemTaskRegistry systemTaskRegistry,
-            @Qualifier("taskMappersByTaskType") Map<TaskType, TaskMapper> taskMappers,
+            @Qualifier("taskMappersByTaskType") Map<String, TaskMapper> taskMappers,
             @Value("${conductor.app.taskPendingTimeThreshold:60m}")
                     Duration taskPendingTimeThreshold) {
         this.idGenerator = idGenerator;
@@ -830,7 +831,6 @@ public class DeciderService {
                         taskToSchedule.getInputParameters(), workflow, null, null);
 
         String type = taskToSchedule.getType();
-        TaskType taskType = TaskType.of(type);
 
         // get tasks already scheduled (in progress/terminal) for  this workflow instance
         List<String> tasksInWorkflow =
@@ -860,7 +860,10 @@ public class DeciderService {
         // fork.
         // A new task must only be scheduled if a task, with the same reference name is not already
         // in this workflow instance
-        return taskMappers.get(taskType).getMappedTasks(taskMapperContext).stream()
+        return taskMappers
+                .getOrDefault(type, taskMappers.get(USER_DEFINED.name()))
+                .getMappedTasks(taskMapperContext)
+                .stream()
                 .filter(task -> !tasksInWorkflow.contains(task.getReferenceTaskName()))
                 .collect(Collectors.toList());
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1382,8 +1382,8 @@ public class WorkflowExecutor {
         try {
 
             WorkflowModel workflow = executionDAOFacade.getWorkflowModel(workflowId, true);
-            if(workflow == null) {
-                //This can happen if the workflowId is incorrect
+            if (workflow == null) {
+                // This can happen if the workflowId is incorrect
                 return null;
             }
             // FIXME Backwards compatibility for legacy workflows already running.

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -153,22 +153,24 @@ public class TestDeciderOutcomes {
         taskDef.setResponseTimeoutSeconds(60 * 60);
         when(metadataDAO.getTaskDef(anyString())).thenReturn(taskDef);
         ParametersUtils parametersUtils = new ParametersUtils(objectMapper);
-        Map<TaskType, TaskMapper> taskMappers = new HashMap<>();
-        taskMappers.put(DECISION, new DecisionTaskMapper());
-        taskMappers.put(SWITCH, new SwitchTaskMapper(evaluators));
-        taskMappers.put(DYNAMIC, new DynamicTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(FORK_JOIN, new ForkJoinTaskMapper());
-        taskMappers.put(JOIN, new JoinTaskMapper());
+        Map<String, TaskMapper> taskMappers = new HashMap<>();
+        taskMappers.put(DECISION.name(), new DecisionTaskMapper());
+        taskMappers.put(SWITCH.name(), new SwitchTaskMapper(evaluators));
+        taskMappers.put(DYNAMIC.name(), new DynamicTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(FORK_JOIN.name(), new ForkJoinTaskMapper());
+        taskMappers.put(JOIN.name(), new JoinTaskMapper());
         taskMappers.put(
-                FORK_JOIN_DYNAMIC,
+                FORK_JOIN_DYNAMIC.name(),
                 new ForkJoinDynamicTaskMapper(
                         new IDGenerator(), parametersUtils, objectMapper, metadataDAO));
-        taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
-        taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(EVENT, new EventTaskMapper(parametersUtils));
-        taskMappers.put(WAIT, new WaitTaskMapper(parametersUtils));
-        taskMappers.put(HTTP, new HTTPTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(
+                USER_DEFINED.name(), new UserDefinedTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(SIMPLE.name(), new SimpleTaskMapper(parametersUtils));
+        taskMappers.put(
+                SUB_WORKFLOW.name(), new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(EVENT.name(), new EventTaskMapper(parametersUtils));
+        taskMappers.put(WAIT.name(), new WaitTaskMapper(parametersUtils));
+        taskMappers.put(HTTP.name(), new HTTPTaskMapper(parametersUtils, metadataDAO));
 
         this.deciderService =
                 new DeciderService(

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -105,9 +105,9 @@ public class TestDeciderService {
         }
 
         @Bean
-        public Map<TaskType, TaskMapper> taskMapperMap(Collection<TaskMapper> taskMappers) {
+        public Map<String, TaskMapper> taskMapperMap(Collection<TaskMapper> taskMappers) {
             return taskMappers.stream()
-                    .collect(Collectors.toMap(TaskMapper::getTaskType, Function.identity()));
+                    .collect(Collectors.toMap(t -> t.getTaskType().name(), Function.identity()));
         }
 
         @Bean
@@ -132,7 +132,7 @@ public class TestDeciderService {
 
     @Autowired
     @Qualifier("taskMapperMap")
-    private Map<TaskType, TaskMapper> taskMappers;
+    private Map<String, TaskMapper> taskMappers;
 
     @Autowired private ParametersUtils parametersUtils;
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -159,24 +159,26 @@ public class TestWorkflowExecutor {
         executionLockService = mock(ExecutionLockService.class);
         ParametersUtils parametersUtils = new ParametersUtils(objectMapper);
         IDGenerator idGenerator = new IDGenerator();
-        Map<TaskType, TaskMapper> taskMappers = new HashMap<>();
-        taskMappers.put(DECISION, new DecisionTaskMapper());
-        taskMappers.put(SWITCH, new SwitchTaskMapper(evaluators));
-        taskMappers.put(DYNAMIC, new DynamicTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(FORK_JOIN, new ForkJoinTaskMapper());
-        taskMappers.put(JOIN, new JoinTaskMapper());
+        Map<String, TaskMapper> taskMappers = new HashMap<>();
+        taskMappers.put(DECISION.name(), new DecisionTaskMapper());
+        taskMappers.put(SWITCH.name(), new SwitchTaskMapper(evaluators));
+        taskMappers.put(DYNAMIC.name(), new DynamicTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(FORK_JOIN.name(), new ForkJoinTaskMapper());
+        taskMappers.put(JOIN.name(), new JoinTaskMapper());
         taskMappers.put(
-                FORK_JOIN_DYNAMIC,
+                FORK_JOIN_DYNAMIC.name(),
                 new ForkJoinDynamicTaskMapper(
                         idGenerator, parametersUtils, objectMapper, metadataDAO));
-        taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
-        taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(EVENT, new EventTaskMapper(parametersUtils));
-        taskMappers.put(WAIT, new WaitTaskMapper(parametersUtils));
-        taskMappers.put(HTTP, new HTTPTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(LAMBDA, new LambdaTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(INLINE, new InlineTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(
+                USER_DEFINED.name(), new UserDefinedTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(SIMPLE.name(), new SimpleTaskMapper(parametersUtils));
+        taskMappers.put(
+                SUB_WORKFLOW.name(), new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(EVENT.name(), new EventTaskMapper(parametersUtils));
+        taskMappers.put(WAIT.name(), new WaitTaskMapper(parametersUtils));
+        taskMappers.put(HTTP.name(), new HTTPTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(LAMBDA.name(), new LambdaTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(INLINE.name(), new InlineTaskMapper(parametersUtils, metadataDAO));
 
         DeciderService deciderService =
                 new DeciderService(


### PR DESCRIPTION
Use enum.name() where needed, change map types to HashMap<String, TaskMapper>, fix tests

Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Conductor already had some potential for the addition of custom system task types by using String for types in SystemTaskRegistry, but a bean with the qualifier `taskMappersByTaskType` in CoreConfiguration prevented us from doing that. This PR will allow us to go further and add custom system task types with their respective task mappers by overriding aforementioned Bean.


Alternatives considered
----

_Describe alternative implementation you have considered_
