### PR TITLE
Changing task mapper interface to make it extensible.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorCoreConfiguration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorCoreConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
-import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 import com.netflix.conductor.core.events.EventQueueProvider;
 import com.netflix.conductor.core.execution.mapper.TaskMapper;
@@ -98,8 +97,9 @@ public class ConductorCoreConfiguration {
 
     @Bean
     @Qualifier("taskMappersByTaskType")
-    public Map<TaskType, TaskMapper> getTaskMappers(List<TaskMapper> taskMappers) {
-        return taskMappers.stream().collect(Collectors.toMap(TaskMapper::getTaskType, identity()));
+    public Map<String, TaskMapper> getTaskMappers(List<TaskMapper> taskMappers) {
+        return taskMappers.stream()
+                .collect(Collectors.toMap(t -> t.getTaskType(), identity()));
     }
 
     @Bean

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -44,6 +44,7 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TERMINATE;
+import static com.netflix.conductor.common.metadata.tasks.TaskType.USER_DEFINED;
 import static com.netflix.conductor.model.TaskModel.Status.*;
 
 /**
@@ -63,7 +64,7 @@ public class DeciderService {
     private final SystemTaskRegistry systemTaskRegistry;
     private final long taskPendingTimeThresholdMins;
 
-    private final Map<TaskType, TaskMapper> taskMappers;
+    private final Map<String, TaskMapper> taskMappers;
 
     public DeciderService(
             IDGenerator idGenerator,
@@ -71,7 +72,7 @@ public class DeciderService {
             MetadataDAO metadataDAO,
             ExternalPayloadStorageUtils externalPayloadStorageUtils,
             SystemTaskRegistry systemTaskRegistry,
-            @Qualifier("taskMappersByTaskType") Map<TaskType, TaskMapper> taskMappers,
+            @Qualifier("taskMappersByTaskType") Map<String, TaskMapper> taskMappers,
             @Value("${conductor.app.taskPendingTimeThreshold:60m}")
                     Duration taskPendingTimeThreshold) {
         this.idGenerator = idGenerator;
@@ -830,7 +831,6 @@ public class DeciderService {
                         taskToSchedule.getInputParameters(), workflow, null, null);
 
         String type = taskToSchedule.getType();
-        TaskType taskType = TaskType.of(type);
 
         // get tasks already scheduled (in progress/terminal) for  this workflow instance
         List<String> tasksInWorkflow =
@@ -860,7 +860,10 @@ public class DeciderService {
         // fork.
         // A new task must only be scheduled if a task, with the same reference name is not already
         // in this workflow instance
-        return taskMappers.get(taskType).getMappedTasks(taskMapperContext).stream()
+        return taskMappers
+                .getOrDefault(type, taskMappers.get(USER_DEFINED.name()))
+                .getMappedTasks(taskMapperContext)
+                .stream()
                 .filter(task -> !tasksInWorkflow.contains(task.getReferenceTaskName()))
                 .collect(Collectors.toList());
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1382,8 +1382,8 @@ public class WorkflowExecutor {
         try {
 
             WorkflowModel workflow = executionDAOFacade.getWorkflowModel(workflowId, true);
-            if(workflow == null) {
-                //This can happen if the workflowId is incorrect
+            if (workflow == null) {
+                // This can happen if the workflowId is incorrect
                 return null;
             }
             // FIXME Backwards compatibility for legacy workflows already running.

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
@@ -50,8 +50,8 @@ public class DecisionTaskMapper implements TaskMapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(DecisionTaskMapper.class);
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.DECISION;
+    public String getTaskType() {
+        return TaskType.DECISION.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
@@ -45,8 +45,8 @@ public class DoWhileTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.DO_WHILE;
+    public String getTaskType() {
+        return TaskType.DO_WHILE.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DynamicTaskMapper.java
@@ -53,8 +53,8 @@ public class DynamicTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.DYNAMIC;
+    public String getTaskType() {
+        return TaskType.DYNAMIC.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/EventTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/EventTaskMapper.java
@@ -41,8 +41,8 @@ public class EventTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.EVENT;
+    public String getTaskType() {
+        return TaskType.EVENT.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ExclusiveJoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ExclusiveJoinTaskMapper.java
@@ -30,8 +30,8 @@ public class ExclusiveJoinTaskMapper implements TaskMapper {
     public static final Logger LOGGER = LoggerFactory.getLogger(ExclusiveJoinTaskMapper.class);
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.EXCLUSIVE_JOIN;
+    public String getTaskType() {
+        return TaskType.EXCLUSIVE_JOIN.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -74,8 +74,8 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.FORK_JOIN_DYNAMIC;
+    public String getTaskType() {
+        return TaskType.FORK_JOIN_DYNAMIC.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
@@ -38,8 +38,8 @@ public class ForkJoinTaskMapper implements TaskMapper {
     public static final Logger LOGGER = LoggerFactory.getLogger(ForkJoinTaskMapper.class);
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.FORK_JOIN;
+    public String getTaskType() {
+        return TaskType.FORK_JOIN.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/HTTPTaskMapper.java
@@ -49,8 +49,8 @@ public class HTTPTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.HTTP;
+    public String getTaskType() {
+        return TaskType.HTTP.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/HumanTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/HumanTaskMapper.java
@@ -45,8 +45,8 @@ public class HumanTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.HUMAN;
+    public String getTaskType() {
+        return TaskType.HUMAN.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
@@ -47,8 +47,8 @@ public class InlineTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.INLINE;
+    public String getTaskType() {
+        return TaskType.INLINE.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
@@ -36,8 +36,8 @@ public class JoinTaskMapper implements TaskMapper {
     public static final Logger LOGGER = LoggerFactory.getLogger(JoinTaskMapper.class);
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.JOIN;
+    public String getTaskType() {
+        return TaskType.JOIN.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
@@ -41,8 +41,8 @@ public class JsonJQTransformTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.JSON_JQ_TRANSFORM;
+    public String getTaskType() {
+        return TaskType.JSON_JQ_TRANSFORM.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/KafkaPublishTaskMapper.java
@@ -48,8 +48,8 @@ public class KafkaPublishTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.KAFKA_PUBLISH;
+    public String getTaskType() {
+        return TaskType.KAFKA_PUBLISH.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapper.java
@@ -48,8 +48,8 @@ public class LambdaTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.LAMBDA;
+    public String getTaskType() {
+        return TaskType.LAMBDA.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SetVariableTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SetVariableTaskMapper.java
@@ -28,8 +28,8 @@ public class SetVariableTaskMapper implements TaskMapper {
     public static final Logger LOGGER = LoggerFactory.getLogger(SetVariableTaskMapper.class);
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.SET_VARIABLE;
+    public String getTaskType() {
+        return TaskType.SET_VARIABLE.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
@@ -45,8 +45,8 @@ public class SimpleTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.SIMPLE;
+    public String getTaskType() {
+        return TaskType.SIMPLE.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/StartWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/StartWorkflowTaskMapper.java
@@ -32,8 +32,8 @@ public class StartWorkflowTaskMapper implements TaskMapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(StartWorkflowTaskMapper.class);
 
     @Override
-    public TaskType getTaskType() {
-        return START_WORKFLOW;
+    public String getTaskType() {
+        return START_WORKFLOW.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -45,8 +45,8 @@ public class SubWorkflowTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.SUB_WORKFLOW;
+    public String getTaskType() {
+        return TaskType.SUB_WORKFLOW.name();
     }
 
     @SuppressWarnings("rawtypes")

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
@@ -49,8 +49,8 @@ public class SwitchTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.SWITCH;
+    public String getTaskType() {
+        return TaskType.SWITCH.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/TaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/TaskMapper.java
@@ -20,7 +20,7 @@ import com.netflix.conductor.model.TaskModel;
 
 public interface TaskMapper {
 
-    TaskType getTaskType();
+    String getTaskType();
 
     List<TaskModel> getMappedTasks(TaskMapperContext taskMapperContext)
             throws TerminateWorkflowException;

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/TerminateTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/TerminateTaskMapper.java
@@ -37,8 +37,8 @@ public class TerminateTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.TERMINATE;
+    public String getTaskType() {
+        return TaskType.TERMINATE.name();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/UserDefinedTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/UserDefinedTaskMapper.java
@@ -49,8 +49,8 @@ public class UserDefinedTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.USER_DEFINED;
+    public String getTaskType() {
+        return TaskType.USER_DEFINED.name();
     }
 
     /**

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
@@ -45,8 +45,8 @@ public class WaitTaskMapper implements TaskMapper {
     }
 
     @Override
-    public TaskType getTaskType() {
-        return TaskType.WAIT;
+    public String getTaskType() {
+        return TaskType.WAIT.name();
     }
 
     @Override

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -153,22 +153,24 @@ public class TestDeciderOutcomes {
         taskDef.setResponseTimeoutSeconds(60 * 60);
         when(metadataDAO.getTaskDef(anyString())).thenReturn(taskDef);
         ParametersUtils parametersUtils = new ParametersUtils(objectMapper);
-        Map<TaskType, TaskMapper> taskMappers = new HashMap<>();
-        taskMappers.put(DECISION, new DecisionTaskMapper());
-        taskMappers.put(SWITCH, new SwitchTaskMapper(evaluators));
-        taskMappers.put(DYNAMIC, new DynamicTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(FORK_JOIN, new ForkJoinTaskMapper());
-        taskMappers.put(JOIN, new JoinTaskMapper());
+        Map<String, TaskMapper> taskMappers = new HashMap<>();
+        taskMappers.put(DECISION.name(), new DecisionTaskMapper());
+        taskMappers.put(SWITCH.name(), new SwitchTaskMapper(evaluators));
+        taskMappers.put(DYNAMIC.name(), new DynamicTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(FORK_JOIN.name(), new ForkJoinTaskMapper());
+        taskMappers.put(JOIN.name(), new JoinTaskMapper());
         taskMappers.put(
-                FORK_JOIN_DYNAMIC,
+                FORK_JOIN_DYNAMIC.name(),
                 new ForkJoinDynamicTaskMapper(
                         new IDGenerator(), parametersUtils, objectMapper, metadataDAO));
-        taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
-        taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(EVENT, new EventTaskMapper(parametersUtils));
-        taskMappers.put(WAIT, new WaitTaskMapper(parametersUtils));
-        taskMappers.put(HTTP, new HTTPTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(
+                USER_DEFINED.name(), new UserDefinedTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(SIMPLE.name(), new SimpleTaskMapper(parametersUtils));
+        taskMappers.put(
+                SUB_WORKFLOW.name(), new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(EVENT.name(), new EventTaskMapper(parametersUtils));
+        taskMappers.put(WAIT.name(), new WaitTaskMapper(parametersUtils));
+        taskMappers.put(HTTP.name(), new HTTPTaskMapper(parametersUtils, metadataDAO));
 
         this.deciderService =
                 new DeciderService(

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -105,9 +105,9 @@ public class TestDeciderService {
         }
 
         @Bean
-        public Map<TaskType, TaskMapper> taskMapperMap(Collection<TaskMapper> taskMappers) {
+        public Map<String, TaskMapper> taskMapperMap(Collection<TaskMapper> taskMappers) {
             return taskMappers.stream()
-                    .collect(Collectors.toMap(TaskMapper::getTaskType, Function.identity()));
+                    .collect(Collectors.toMap(t -> t.getTaskType(), Function.identity()));
         }
 
         @Bean
@@ -132,7 +132,7 @@ public class TestDeciderService {
 
     @Autowired
     @Qualifier("taskMapperMap")
-    private Map<TaskType, TaskMapper> taskMappers;
+    private Map<String, TaskMapper> taskMappers;
 
     @Autowired private ParametersUtils parametersUtils;
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -159,24 +159,26 @@ public class TestWorkflowExecutor {
         executionLockService = mock(ExecutionLockService.class);
         ParametersUtils parametersUtils = new ParametersUtils(objectMapper);
         IDGenerator idGenerator = new IDGenerator();
-        Map<TaskType, TaskMapper> taskMappers = new HashMap<>();
-        taskMappers.put(DECISION, new DecisionTaskMapper());
-        taskMappers.put(SWITCH, new SwitchTaskMapper(evaluators));
-        taskMappers.put(DYNAMIC, new DynamicTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(FORK_JOIN, new ForkJoinTaskMapper());
-        taskMappers.put(JOIN, new JoinTaskMapper());
+        Map<String, TaskMapper> taskMappers = new HashMap<>();
+        taskMappers.put(DECISION.name(), new DecisionTaskMapper());
+        taskMappers.put(SWITCH.name(), new SwitchTaskMapper(evaluators));
+        taskMappers.put(DYNAMIC.name(), new DynamicTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(FORK_JOIN.name(), new ForkJoinTaskMapper());
+        taskMappers.put(JOIN.name(), new JoinTaskMapper());
         taskMappers.put(
-                FORK_JOIN_DYNAMIC,
+                FORK_JOIN_DYNAMIC.name(),
                 new ForkJoinDynamicTaskMapper(
                         idGenerator, parametersUtils, objectMapper, metadataDAO));
-        taskMappers.put(USER_DEFINED, new UserDefinedTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(SIMPLE, new SimpleTaskMapper(parametersUtils));
-        taskMappers.put(SUB_WORKFLOW, new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(EVENT, new EventTaskMapper(parametersUtils));
-        taskMappers.put(WAIT, new WaitTaskMapper(parametersUtils));
-        taskMappers.put(HTTP, new HTTPTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(LAMBDA, new LambdaTaskMapper(parametersUtils, metadataDAO));
-        taskMappers.put(INLINE, new InlineTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(
+                USER_DEFINED.name(), new UserDefinedTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(SIMPLE.name(), new SimpleTaskMapper(parametersUtils));
+        taskMappers.put(
+                SUB_WORKFLOW.name(), new SubWorkflowTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(EVENT.name(), new EventTaskMapper(parametersUtils));
+        taskMappers.put(WAIT.name(), new WaitTaskMapper(parametersUtils));
+        taskMappers.put(HTTP.name(), new HTTPTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(LAMBDA.name(), new LambdaTaskMapper(parametersUtils, metadataDAO));
+        taskMappers.put(INLINE.name(), new InlineTaskMapper(parametersUtils, metadataDAO));
 
         DeciderService deciderService =
                 new DeciderService(


### PR DESCRIPTION
Pull Request type
----

- [X] Refactoring (no functional changes, no api changes)

Changed TaskMapper.getTaskType to return String instead of TaskType. This way we dont need to add a custom task mapper in the core configuration explicitly. 