### PR TITLE
New Action types for Event Handlers - terminate_workflow, update_workflow_variables

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
@@ -147,7 +147,9 @@ public class EventHandler {
         public enum Type {
             start_workflow,
             complete_task,
-            fail_task
+            fail_task,
+            terminate_workflow,
+            update_workflow_variables
         }
 
         @ProtoField(id = 1)
@@ -164,6 +166,12 @@ public class EventHandler {
 
         @ProtoField(id = 5)
         private boolean expandInlineJSON;
+
+        @ProtoField(id = 6)
+        private TerminateWorkflow terminate_workflow;
+
+        @ProtoField(id = 7)
+        private UpdateWorkflowVariables update_workflow_variables;
 
         /**
          * @return the action
@@ -234,6 +242,35 @@ public class EventHandler {
          */
         public boolean isExpandInlineJSON() {
             return expandInlineJSON;
+        }
+
+        /**
+         * @return the terminate_workflow
+         */
+        public TerminateWorkflow getTerminate_workflow() {
+            return terminate_workflow;
+        }
+
+        /**
+         * @param terminate_workflow the fail_task to set
+         */
+        public void setTerminate_workflow(TerminateWorkflow terminate_workflow) {
+            this.terminate_workflow = terminate_workflow;
+        }
+
+        /**
+         * @return the update_workflow_variables
+         */
+        public UpdateWorkflowVariables getUpdate_workflow_variables() {
+            return update_workflow_variables;
+        }
+
+        /**
+         * @param update_workflow_variables the fail_task to set
+         */
+        public void setUpdate_workflow_variables(
+                UpdateWorkflowVariables update_workflow_variables) {
+            this.update_workflow_variables = update_workflow_variables;
         }
     }
 
@@ -413,6 +450,82 @@ public class EventHandler {
 
         public void setTaskToDomain(Map<String, String> taskToDomain) {
             this.taskToDomain = taskToDomain;
+        }
+    }
+
+    @ProtoMessage
+    public static class TerminateWorkflow {
+
+        @ProtoField(id = 1)
+        private String workflowId;
+
+        @ProtoField(id = 2)
+        private String terminationReason;
+
+        /**
+         * @return the workflowId
+         */
+        public String getWorkflowId() {
+            return workflowId;
+        }
+
+        /**
+         * @param workflowId the workflowId to set
+         */
+        public void setWorkflowId(String workflowId) {
+            this.workflowId = workflowId;
+        }
+
+        /**
+         * @return the reasonForTermination
+         */
+        public String getTerminationReason() {
+            return terminationReason;
+        }
+
+        /**
+         * @param terminationReason the reasonForTermination to set
+         */
+        public void setTerminationReason(String terminationReason) {
+            this.terminationReason = terminationReason;
+        }
+    }
+
+    @ProtoMessage
+    public static class UpdateWorkflowVariables {
+
+        @ProtoField(id = 1)
+        private String workflowId;
+
+        @ProtoField(id = 2)
+        private Map<String, Object> variables;
+
+        /**
+         * @return the workflowId
+         */
+        public String getWorkflowId() {
+            return workflowId;
+        }
+
+        /**
+         * @param workflowId the workflowId to set
+         */
+        public void setWorkflowId(String workflowId) {
+            this.workflowId = workflowId;
+        }
+
+        /**
+         * @return the variables
+         */
+        public Map<String, Object> getVariables() {
+            return variables;
+        }
+
+        /**
+         * @param variables the variables to set
+         */
+        public void setVariables(Map<String, Object> variables) {
+            this.variables = variables;
         }
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
@@ -252,7 +252,7 @@ public class EventHandler {
         }
 
         /**
-         * @param terminate_workflow the fail_task to set
+         * @param terminate_workflow the terminate_workflow to set
          */
         public void setTerminate_workflow(TerminateWorkflow terminate_workflow) {
             this.terminate_workflow = terminate_workflow;
@@ -266,7 +266,7 @@ public class EventHandler {
         }
 
         /**
-         * @param update_workflow_variables the fail_task to set
+         * @param update_workflow_variables the update_workflow_variables to set
          */
         public void setUpdate_workflow_variables(
                 UpdateWorkflowVariables update_workflow_variables) {

--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -24,11 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.netflix.conductor.common.metadata.events.EventHandler.Action;
-import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
-import com.netflix.conductor.common.metadata.events.EventHandler.TaskDetails;
+import com.netflix.conductor.common.metadata.events.EventHandler.*;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import com.netflix.conductor.common.utils.TaskUtils;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.utils.JsonUtils;
 import com.netflix.conductor.core.utils.ParametersUtils;
@@ -48,14 +47,17 @@ public class SimpleActionProcessor implements ActionProcessor {
     private final WorkflowExecutor workflowExecutor;
     private final ParametersUtils parametersUtils;
     private final JsonUtils jsonUtils;
+    private final ExecutionDAOFacade executionDAOFacade;
 
     public SimpleActionProcessor(
             WorkflowExecutor workflowExecutor,
             ParametersUtils parametersUtils,
-            JsonUtils jsonUtils) {
+            JsonUtils jsonUtils,
+            ExecutionDAOFacade executionDAOFacade) {
         this.workflowExecutor = workflowExecutor;
         this.parametersUtils = parametersUtils;
         this.jsonUtils = jsonUtils;
+        this.executionDAOFacade = executionDAOFacade;
     }
 
     public Map<String, Object> execute(
@@ -91,6 +93,10 @@ public class SimpleActionProcessor implements ActionProcessor {
                         TaskModel.Status.FAILED,
                         event,
                         messageId);
+            case terminate_workflow:
+                return terminateWorkflow(action, jsonObject, event, messageId);
+            case update_workflow_variables:
+                return updateWorkflowVariables(action, jsonObject, event, messageId);
             default:
                 break;
         }
@@ -232,6 +238,86 @@ public class SimpleActionProcessor implements ActionProcessor {
                     "Error starting workflow: {}, version: {}, for event: {} for message: {}",
                     params.getName(),
                     params.getVersion(),
+                    event,
+                    messageId,
+                    e);
+            output.put("error", e.getMessage());
+            throw e;
+        }
+        return output;
+    }
+
+    private Map<String, Object> terminateWorkflow(
+            Action action, Object payload, String event, String messageId) {
+        TerminateWorkflow params = action.getTerminate_workflow();
+        Map<String, Object> output = new HashMap<>();
+        try {
+            Map<String, Object> input = new HashMap<>();
+            input.put("workflowId", params.getWorkflowId());
+            input.put("terminationReason", params.getTerminationReason());
+
+            Map<String, Object> replaced = parametersUtils.replace(input, payload);
+            String workflowId = (String) replaced.get("workflowId");
+            String reasonForTermination = (String) replaced.get("terminationReason");
+
+            workflowExecutor.terminateWorkflow(workflowId, reasonForTermination);
+            output.put("workflowId", workflowId);
+            output.put("terminationReason", reasonForTermination);
+            LOGGER.debug(
+                    "Terminated workflow: {} for event: {} for message:{}",
+                    workflowId,
+                    event,
+                    messageId);
+
+        } catch (RuntimeException e) {
+            Monitors.recordEventActionError(
+                    action.getAction().name(), params.getWorkflowId(), event);
+            LOGGER.error(
+                    "Error terminating workflow: {}, for event: {} for message: {}",
+                    params.getWorkflowId(),
+                    event,
+                    messageId,
+                    e);
+            output.put("error", e.getMessage());
+            throw e;
+        }
+        return output;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> updateWorkflowVariables(
+            Action action, Object payload, String event, String messageId) {
+        UpdateWorkflowVariables params = action.getUpdate_workflow_variables();
+        Map<String, Object> output = new HashMap<>();
+        try {
+            Map<String, Object> input = new HashMap<>();
+            input.put("workflowId", params.getWorkflowId());
+            input.put("variables", params.getVariables());
+
+            Map<String, Object> replaced = parametersUtils.replace(input, payload);
+            String workflowId = (String) replaced.get("workflowId");
+            Map<String, Object> variables = (Map<String, Object>) replaced.get("variables");
+            WorkflowModel workflow = workflowExecutor.getWorkflow(workflowId, false);
+            variables.forEach((k, v) -> workflow.getVariables().put(k, v));
+            executionDAOFacade.updateWorkflow(workflow);
+            workflowExecutor.decide(workflowId);
+
+            output.put("workflowId", workflowId);
+            output.put("variables", variables);
+            LOGGER.debug(
+                    "Updated variables for workflow: {}/{}/{} for event: {} for message: {}",
+                    workflow.getWorkflowName(),
+                    workflow.getWorkflowVersion(),
+                    workflowId,
+                    event,
+                    messageId);
+
+        } catch (RuntimeException e) {
+            Monitors.recordEventActionError(
+                    action.getAction().name(), params.getWorkflowId(), event);
+            LOGGER.error(
+                    "Error updating variables for workflow: {}, for event: {} for message: {}",
+                    params.getWorkflowId(),
                     event,
                     messageId,
                     e);

--- a/core/src/test/java/com/netflix/conductor/core/events/TestDefaultEventProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestDefaultEventProcessor.java
@@ -37,6 +37,7 @@ import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
 import com.netflix.conductor.common.metadata.events.EventHandler.TaskDetails;
 import com.netflix.conductor.core.config.ConductorCoreConfiguration;
 import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.core.exception.ApplicationException;
@@ -70,6 +71,7 @@ public class TestDefaultEventProcessor {
     private ObservableQueue queue;
     private MetadataService metadataService;
     private ExecutionService executionService;
+    private ExecutionDAOFacade executionDAOFacade;
     private WorkflowExecutor workflowExecutor;
     private ExternalPayloadStorageUtils externalPayloadStorageUtils;
     private SimpleActionProcessor actionProcessor;
@@ -96,6 +98,7 @@ public class TestDefaultEventProcessor {
 
         metadataService = mock(MetadataService.class);
         executionService = mock(ExecutionService.class);
+        executionDAOFacade = mock(ExecutionDAOFacade.class);
         workflowExecutor = mock(WorkflowExecutor.class);
         externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         actionProcessor = mock(SimpleActionProcessor.class);
@@ -189,7 +192,8 @@ public class TestDefaultEventProcessor {
         doNothing().when(externalPayloadStorageUtils).verifyAndUpload(any(), any());
 
         SimpleActionProcessor actionProcessor =
-                new SimpleActionProcessor(workflowExecutor, parametersUtils, jsonUtils);
+                new SimpleActionProcessor(
+                        workflowExecutor, parametersUtils, jsonUtils, executionDAOFacade);
 
         DefaultEventProcessor eventProcessor =
                 new DefaultEventProcessor(
@@ -256,7 +260,8 @@ public class TestDefaultEventProcessor {
                         eq(null));
 
         SimpleActionProcessor actionProcessor =
-                new SimpleActionProcessor(workflowExecutor, parametersUtils, jsonUtils);
+                new SimpleActionProcessor(
+                        workflowExecutor, parametersUtils, jsonUtils, executionDAOFacade);
 
         DefaultEventProcessor eventProcessor =
                 new DefaultEventProcessor(
@@ -321,7 +326,8 @@ public class TestDefaultEventProcessor {
                         eq(null));
 
         SimpleActionProcessor actionProcessor =
-                new SimpleActionProcessor(workflowExecutor, parametersUtils, jsonUtils);
+                new SimpleActionProcessor(
+                        workflowExecutor, parametersUtils, jsonUtils, executionDAOFacade);
 
         DefaultEventProcessor eventProcessor =
                 new DefaultEventProcessor(

--- a/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.events;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,13 +25,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
-import com.netflix.conductor.common.metadata.events.EventHandler.Action;
+import com.netflix.conductor.common.metadata.events.EventHandler.*;
 import com.netflix.conductor.common.metadata.events.EventHandler.Action.Type;
-import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
-import com.netflix.conductor.common.metadata.events.EventHandler.TaskDetails;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import com.netflix.conductor.common.metadata.tasks.TaskResult.Status;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
 import com.netflix.conductor.core.utils.JsonUtils;
@@ -60,6 +60,7 @@ public class TestSimpleActionProcessor {
     private WorkflowExecutor workflowExecutor;
     private ExternalPayloadStorageUtils externalPayloadStorageUtils;
     private SimpleActionProcessor actionProcessor;
+    private ExecutionDAOFacade executionDAOFacade;
 
     @Autowired private ObjectMapper objectMapper;
 
@@ -69,11 +70,14 @@ public class TestSimpleActionProcessor {
 
         workflowExecutor = mock(WorkflowExecutor.class);
 
+        executionDAOFacade = mock(ExecutionDAOFacade.class);
+
         actionProcessor =
                 new SimpleActionProcessor(
                         workflowExecutor,
                         new ParametersUtils(objectMapper),
-                        new JsonUtils(objectMapper));
+                        new JsonUtils(objectMapper),
+                        executionDAOFacade);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -317,5 +321,65 @@ public class TestSimpleActionProcessor {
                 "testEvent", argumentCaptor.getValue().getOutputData().get("conductor.event.name"));
         assertEquals("workflow_1", argumentCaptor.getValue().getOutputData().get("workflowId"));
         assertEquals("task_1", argumentCaptor.getValue().getOutputData().get("taskId"));
+    }
+
+    @Test
+    public void testTerminateWorkflow() throws Exception {
+        TerminateWorkflow terminateWorkflow = new TerminateWorkflow();
+        terminateWorkflow.setWorkflowId(UUID.randomUUID().toString());
+        terminateWorkflow.setTerminationReason("${reason}");
+
+        Action action = new Action();
+        action.setAction(Type.terminate_workflow);
+        action.setTerminate_workflow(terminateWorkflow);
+
+        Object payload = objectMapper.readValue("{\"reason\":\"terminated\"}", Object.class);
+
+        Map<String, Object> output =
+                actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        assertNotNull(output);
+        assertEquals(terminateWorkflow.getWorkflowId(), output.get("workflowId"));
+        assertEquals("terminated", output.get("terminationReason"));
+
+        verify(workflowExecutor)
+                .terminateWorkflow(eq(terminateWorkflow.getWorkflowId()), eq("terminated"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUpdateWorkflowVariables() throws Exception {
+        UpdateWorkflowVariables updateWorkflowVariables = new UpdateWorkflowVariables();
+        updateWorkflowVariables.setWorkflowId(UUID.randomUUID().toString());
+        Map<String, Object> updateVariablesMap = new HashMap<>();
+        updateVariablesMap.put("variable1", "${key}");
+        updateWorkflowVariables.setVariables(updateVariablesMap);
+
+        Action action = new Action();
+        action.setAction(Type.update_workflow_variables);
+        action.setUpdate_workflow_variables(updateWorkflowVariables);
+
+        Object payload = objectMapper.readValue("{\"key\":\"value\"}", Object.class);
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.getVariables().put("variable1", "test");
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("testWorkflow");
+        workflowDef.setVersion(1);
+        workflowModel.setWorkflowDefinition(workflowDef);
+
+        when(workflowExecutor.getWorkflow(eq(updateWorkflowVariables.getWorkflowId()), eq(false)))
+                .thenReturn(workflowModel);
+
+        Map<String, Object> output =
+                actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        assertNotNull(output);
+        assertEquals(updateWorkflowVariables.getWorkflowId(), output.get("workflowId"));
+        assertNotNull(output.get("variables"));
+        Map<String, Object> outputVariables = (Map<String, Object>) output.get("variables");
+        assertEquals("value", outputVariables.get("variable1"));
+
+        verify(executionDAOFacade).updateWorkflow(eq(workflowModel));
+        verify(workflowExecutor).decide(eq(updateWorkflowVariables.getWorkflowId()));
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Feature
----

Add new action types: `terminate_workflow` and `updateWorkflowVariables`.
The first one accepts `workflowId` and `terminationReason` to terminate a workflow, second one accepts `workflowId` and `variables` map, and replaces variables in execution data of that workflow with variables as defined in that map and then runs decide on it.
