### PR TITLE
New Action types for Event Handlers - terminate workflow, update workflow variables

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
@@ -147,7 +147,9 @@ public class EventHandler {
         public enum Type {
             start_workflow,
             complete_task,
-            fail_task
+            fail_task,
+            terminate_workflow,
+            update_workflow_variables
         }
 
         @ProtoField(id = 1)
@@ -164,6 +166,12 @@ public class EventHandler {
 
         @ProtoField(id = 5)
         private boolean expandInlineJSON;
+
+        @ProtoField(id = 6)
+        private TerminateWorkflow terminate_workflow;
+
+        @ProtoField(id = 7)
+        private UpdateWorkflowVariables update_workflow_variables;
 
         /**
          * @return the action
@@ -234,6 +242,35 @@ public class EventHandler {
          */
         public boolean isExpandInlineJSON() {
             return expandInlineJSON;
+        }
+
+        /**
+         * @return the terminate_workflow
+         */
+        public TerminateWorkflow getTerminate_workflow() {
+            return terminate_workflow;
+        }
+
+        /**
+         * @param terminate_workflow the terminate_workflow to set
+         */
+        public void setTerminate_workflow(TerminateWorkflow terminate_workflow) {
+            this.terminate_workflow = terminate_workflow;
+        }
+
+        /**
+         * @return the update_workflow_variables
+         */
+        public UpdateWorkflowVariables getUpdate_workflow_variables() {
+            return update_workflow_variables;
+        }
+
+        /**
+         * @param update_workflow_variables the update_workflow_variables to set
+         */
+        public void setUpdate_workflow_variables(
+                UpdateWorkflowVariables update_workflow_variables) {
+            this.update_workflow_variables = update_workflow_variables;
         }
     }
 
@@ -413,6 +450,99 @@ public class EventHandler {
 
         public void setTaskToDomain(Map<String, String> taskToDomain) {
             this.taskToDomain = taskToDomain;
+        }
+    }
+
+    @ProtoMessage
+    public static class TerminateWorkflow {
+
+        @ProtoField(id = 1)
+        private String workflowId;
+
+        @ProtoField(id = 2)
+        private String terminationReason;
+
+        /**
+         * @return the workflowId
+         */
+        public String getWorkflowId() {
+            return workflowId;
+        }
+
+        /**
+         * @param workflowId the workflowId to set
+         */
+        public void setWorkflowId(String workflowId) {
+            this.workflowId = workflowId;
+        }
+
+        /**
+         * @return the reasonForTermination
+         */
+        public String getTerminationReason() {
+            return terminationReason;
+        }
+
+        /**
+         * @param terminationReason the reasonForTermination to set
+         */
+        public void setTerminationReason(String terminationReason) {
+            this.terminationReason = terminationReason;
+        }
+    }
+
+    @ProtoMessage
+    public static class UpdateWorkflowVariables {
+
+        @ProtoField(id = 1)
+        private String workflowId;
+
+        @ProtoField(id = 2)
+        private Map<String, Object> variables;
+
+        @ProtoField(id = 3)
+        private Boolean appendArray;
+
+        /**
+         * @return the workflowId
+         */
+        public String getWorkflowId() {
+            return workflowId;
+        }
+
+        /**
+         * @param workflowId the workflowId to set
+         */
+        public void setWorkflowId(String workflowId) {
+            this.workflowId = workflowId;
+        }
+
+        /**
+         * @return the variables
+         */
+        public Map<String, Object> getVariables() {
+            return variables;
+        }
+
+        /**
+         * @param variables the variables to set
+         */
+        public void setVariables(Map<String, Object> variables) {
+            this.variables = variables;
+        }
+
+        /**
+         * @return appendArray
+         */
+        public Boolean isAppendArray() {
+            return appendArray;
+        }
+
+        /**
+         * @param appendArray the appendArray to set
+         */
+        public void setAppendArray(Boolean appendArray) {
+            this.appendArray = appendArray;
         }
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/events/TestDefaultEventProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestDefaultEventProcessor.java
@@ -37,6 +37,7 @@ import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
 import com.netflix.conductor.common.metadata.events.EventHandler.TaskDetails;
 import com.netflix.conductor.core.config.ConductorCoreConfiguration;
 import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.core.exception.TransientException;
@@ -70,6 +71,7 @@ public class TestDefaultEventProcessor {
     private ObservableQueue queue;
     private MetadataService metadataService;
     private ExecutionService executionService;
+    private ExecutionDAOFacade executionDAOFacade;
     private WorkflowExecutor workflowExecutor;
     private ExternalPayloadStorageUtils externalPayloadStorageUtils;
     private SimpleActionProcessor actionProcessor;
@@ -96,6 +98,7 @@ public class TestDefaultEventProcessor {
 
         metadataService = mock(MetadataService.class);
         executionService = mock(ExecutionService.class);
+        executionDAOFacade = mock(ExecutionDAOFacade.class);
         workflowExecutor = mock(WorkflowExecutor.class);
         externalPayloadStorageUtils = mock(ExternalPayloadStorageUtils.class);
         actionProcessor = mock(SimpleActionProcessor.class);
@@ -189,7 +192,8 @@ public class TestDefaultEventProcessor {
         doNothing().when(externalPayloadStorageUtils).verifyAndUpload(any(), any());
 
         SimpleActionProcessor actionProcessor =
-                new SimpleActionProcessor(workflowExecutor, parametersUtils, jsonUtils);
+                new SimpleActionProcessor(
+                        workflowExecutor, parametersUtils, jsonUtils, executionDAOFacade);
 
         DefaultEventProcessor eventProcessor =
                 new DefaultEventProcessor(
@@ -256,7 +260,8 @@ public class TestDefaultEventProcessor {
                         eq(null));
 
         SimpleActionProcessor actionProcessor =
-                new SimpleActionProcessor(workflowExecutor, parametersUtils, jsonUtils);
+                new SimpleActionProcessor(
+                        workflowExecutor, parametersUtils, jsonUtils, executionDAOFacade);
 
         DefaultEventProcessor eventProcessor =
                 new DefaultEventProcessor(
@@ -321,7 +326,8 @@ public class TestDefaultEventProcessor {
                         eq(null));
 
         SimpleActionProcessor actionProcessor =
-                new SimpleActionProcessor(workflowExecutor, parametersUtils, jsonUtils);
+                new SimpleActionProcessor(
+                        workflowExecutor, parametersUtils, jsonUtils, executionDAOFacade);
 
         DefaultEventProcessor eventProcessor =
                 new DefaultEventProcessor(

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -202,6 +202,54 @@ public abstract class AbstractProtoMapper {
         return to;
     }
 
+    public EventHandlerPb.EventHandler.UpdateWorkflowVariables toProto(
+            EventHandler.UpdateWorkflowVariables from) {
+        EventHandlerPb.EventHandler.UpdateWorkflowVariables.Builder to = EventHandlerPb.EventHandler.UpdateWorkflowVariables.newBuilder();
+        if (from.getWorkflowId() != null) {
+            to.setWorkflowId( from.getWorkflowId() );
+        }
+        for (Map.Entry<String, Object> pair : from.getVariables().entrySet()) {
+            to.putVariables( pair.getKey(), toProto( pair.getValue() ) );
+        }
+        if (from.isAppendArray() != null) {
+            to.setAppendArray( from.isAppendArray() );
+        }
+        return to.build();
+    }
+
+    public EventHandler.UpdateWorkflowVariables fromProto(
+            EventHandlerPb.EventHandler.UpdateWorkflowVariables from) {
+        EventHandler.UpdateWorkflowVariables to = new EventHandler.UpdateWorkflowVariables();
+        to.setWorkflowId( from.getWorkflowId() );
+        Map<String, Object> variablesMap = new HashMap<String, Object>();
+        for (Map.Entry<String, Value> pair : from.getVariablesMap().entrySet()) {
+            variablesMap.put( pair.getKey(), fromProto( pair.getValue() ) );
+        }
+        to.setVariables(variablesMap);
+        to.setAppendArray( from.getAppendArray() );
+        return to;
+    }
+
+    public EventHandlerPb.EventHandler.TerminateWorkflow toProto(
+            EventHandler.TerminateWorkflow from) {
+        EventHandlerPb.EventHandler.TerminateWorkflow.Builder to = EventHandlerPb.EventHandler.TerminateWorkflow.newBuilder();
+        if (from.getWorkflowId() != null) {
+            to.setWorkflowId( from.getWorkflowId() );
+        }
+        if (from.getTerminationReason() != null) {
+            to.setTerminationReason( from.getTerminationReason() );
+        }
+        return to.build();
+    }
+
+    public EventHandler.TerminateWorkflow fromProto(
+            EventHandlerPb.EventHandler.TerminateWorkflow from) {
+        EventHandler.TerminateWorkflow to = new EventHandler.TerminateWorkflow();
+        to.setWorkflowId( from.getWorkflowId() );
+        to.setTerminationReason( from.getTerminationReason() );
+        return to;
+    }
+
     public EventHandlerPb.EventHandler.StartWorkflow toProto(EventHandler.StartWorkflow from) {
         EventHandlerPb.EventHandler.StartWorkflow.Builder to = EventHandlerPb.EventHandler.StartWorkflow.newBuilder();
         if (from.getName() != null) {
@@ -291,6 +339,12 @@ public abstract class AbstractProtoMapper {
             to.setFailTask( toProto( from.getFail_task() ) );
         }
         to.setExpandInlineJson( from.isExpandInlineJSON() );
+        if (from.getTerminate_workflow() != null) {
+            to.setTerminateWorkflow( toProto( from.getTerminate_workflow() ) );
+        }
+        if (from.getUpdate_workflow_variables() != null) {
+            to.setUpdateWorkflowVariables( toProto( from.getUpdate_workflow_variables() ) );
+        }
         return to.build();
     }
 
@@ -307,6 +361,12 @@ public abstract class AbstractProtoMapper {
             to.setFail_task( fromProto( from.getFailTask() ) );
         }
         to.setExpandInlineJSON( from.getExpandInlineJson() );
+        if (from.hasTerminateWorkflow()) {
+            to.setTerminate_workflow( fromProto( from.getTerminateWorkflow() ) );
+        }
+        if (from.hasUpdateWorkflowVariables()) {
+            to.setUpdate_workflow_variables( fromProto( from.getUpdateWorkflowVariables() ) );
+        }
         return to;
     }
 
@@ -316,6 +376,8 @@ public abstract class AbstractProtoMapper {
             case start_workflow: to = EventHandlerPb.EventHandler.Action.Type.START_WORKFLOW; break;
             case complete_task: to = EventHandlerPb.EventHandler.Action.Type.COMPLETE_TASK; break;
             case fail_task: to = EventHandlerPb.EventHandler.Action.Type.FAIL_TASK; break;
+            case terminate_workflow: to = EventHandlerPb.EventHandler.Action.Type.TERMINATE_WORKFLOW; break;
+            case update_workflow_variables: to = EventHandlerPb.EventHandler.Action.Type.UPDATE_WORKFLOW_VARIABLES; break;
             default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
         }
         return to;
@@ -327,6 +389,8 @@ public abstract class AbstractProtoMapper {
             case START_WORKFLOW: to = EventHandler.Action.Type.start_workflow; break;
             case COMPLETE_TASK: to = EventHandler.Action.Type.complete_task; break;
             case FAIL_TASK: to = EventHandler.Action.Type.fail_task; break;
+            case TERMINATE_WORKFLOW: to = EventHandler.Action.Type.terminate_workflow; break;
+            case UPDATE_WORKFLOW_VARIABLES: to = EventHandler.Action.Type.update_workflow_variables; break;
             default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
         }
         return to;

--- a/grpc/src/main/proto/model/eventhandler.proto
+++ b/grpc/src/main/proto/model/eventhandler.proto
@@ -9,6 +9,15 @@ option java_outer_classname = "EventHandlerPb";
 option go_package = "github.com/netflix/conductor/client/gogrpc/conductor/model";
 
 message EventHandler {
+    message UpdateWorkflowVariables {
+        string workflow_id = 1;
+        map<string, google.protobuf.Value> variables = 2;
+        bool append_array = 3;
+    }
+    message TerminateWorkflow {
+        string workflow_id = 1;
+        string termination_reason = 2;
+    }
     message StartWorkflow {
         string name = 1;
         int32 version = 2;
@@ -29,12 +38,16 @@ message EventHandler {
             START_WORKFLOW = 0;
             COMPLETE_TASK = 1;
             FAIL_TASK = 2;
+            TERMINATE_WORKFLOW = 3;
+            UPDATE_WORKFLOW_VARIABLES = 4;
         }
         EventHandler.Action.Type action = 1;
         EventHandler.StartWorkflow start_workflow = 2;
         EventHandler.TaskDetails complete_task = 3;
         EventHandler.TaskDetails fail_task = 4;
         bool expand_inline_json = 5;
+        EventHandler.TerminateWorkflow terminate_workflow = 6;
+        EventHandler.UpdateWorkflowVariables update_workflow_variables = 7;
     }
     string name = 1;
     string event = 2;


### PR DESCRIPTION
Pull Request type
----
- [x] Feature
----

Add new action types: `terminate_workflow` and `updateWorkflowVariables`.
The first one accepts `workflowId` and `terminationReason` to terminate a workflow, second one accepts `workflowId` and `variables` map as well as `appendArray` parameter (default true), and replaces variables in execution data of that workflow with variables as defined in that map or turns that variable value into a list and appends a value to it, and then runs decide on the workflow.
