### PR TITLE
Decider fix

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -413,10 +413,10 @@ public class WorkflowExecutor {
                     workflow.getWorkflowName(),
                     workflow.getWorkflowId());
             executionDAOFacade.populateWorkflowAndTaskPayloadData(workflow);
-            int hashCode = workflow.hashCode();
+            int hashCodeBeforeDecider = workflow.hashCode();
             WorkflowModel workflowModel = decide(workflow);
             int hashCodeAfterDecider = workflowModel.hashCode();
-            if (hashCodeAfterDecider != hashCode) {
+            if (hashCodeAfterDecider != hashCodeBeforeDecider) {
                 // Since hashCode is different there has been some update which needs to be saved.
                 executionDAOFacade.updateWorkflow(workflowModel);
             }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1455,7 +1455,8 @@ public class WorkflowExecutor {
             if (!outcome.tasksToBeUpdated.isEmpty() || !tasksToBeScheduled.isEmpty()) {
                 executionDAOFacade.updateWorkflow(workflow);
             }
-
+            // Update the workflow to save workflow attributes.
+            executionDAOFacade.updateWorkflow(workflow);
             return workflow;
 
         } catch (TerminateWorkflowException twe) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -528,7 +528,13 @@ public class WorkflowExecutor {
             createWorkflow(workflow);
             executionDAOFacade.populateWorkflowAndTaskPayloadData(workflow);
             // then decide to see if anything needs to be done as part of the workflow
-            decide(workflow);
+            int hashCodeBeforeDecider = workflow.hashCode();
+            WorkflowModel workflowModel = decide(workflow);
+            int hashCodeAfterDecider = workflowModel.hashCode();
+            if (hashCodeAfterDecider != hashCodeBeforeDecider) {
+                // Since hashCode is different there has been some update which needs to be saved.
+                executionDAOFacade.updateWorkflow(workflowModel);
+            }
             Monitors.recordWorkflowStartSuccess(
                     workflow.getWorkflowName(),
                     String.valueOf(workflow.getWorkflowVersion()),

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1458,10 +1458,6 @@ public class WorkflowExecutor {
                 return decide(workflow);
             }
 
-            if (!outcome.tasksToBeUpdated.isEmpty() || !tasksToBeScheduled.isEmpty()) {
-                executionDAOFacade.updateWorkflow(workflow);
-            }
-
             return workflow;
 
         } catch (TerminateWorkflowException twe) {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -233,7 +233,7 @@ public class TestDeciderOutcomes {
         workflow.getTasks().addAll(outcome.tasksToBeScheduled);
         outcome = deciderService.decide(workflow);
         assertFalse(outcome.isComplete);
-        assertEquals(outcome.tasksToBeUpdated.toString(), 1, outcome.tasksToBeUpdated.size());
+        assertEquals(outcome.tasksToBeUpdated.toString(), 3, outcome.tasksToBeUpdated.size());
         assertEquals(1, outcome.tasksToBeScheduled.size());
         assertEquals("junit_task_3", outcome.tasksToBeScheduled.get(0).getTaskDefName());
     }

--- a/test-harness/src/test/resources/set_variable_workflow_integration_test.json
+++ b/test-harness/src/test/resources/set_variable_workflow_integration_test.json
@@ -1,0 +1,48 @@
+{
+  "name": "set_variable_workflow_integration_test",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "set_variable",
+      "taskReferenceName": "set_variable_1",
+      "inputParameters": {
+        "var": "${workflow.input.var}"
+      },
+      "type": "SET_VARIABLE",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    },
+    {
+      "name": "wait",
+      "taskReferenceName": "wait0",
+      "inputParameters": {},
+      "type": "WAIT",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {
+    "variables": "${workflow.variables}"
+  },
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Update workflow DAO in case of any workflow-related attribute updates. For example workflow variables. 


_Describe the new behavior from this PR, and why it's needed_
Issue #3211
The issue is when the workflow variable gets computed the state was not getting written back to DAO so if the next task is async and sweeper runs in between then it sees the inconsistent state of the workflow. Here we are writing the workflow state only when there is a change in the workflow state. So overall DAO calls are also not increased.
