### PR TITLE
Task reset feature.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1894,7 +1894,7 @@ public class WorkflowExecutor {
         // On addTaskToQueue failures, ignore the exceptions and let WorkflowRepairService take care
         // of republishing the messages to the queue.
         try {
-            tasksToBeQueued = getActualTasksToBeQueued(tasksToBeQueued, workflow);
+            tasksToBeQueued = getTasksToBeQueued(tasksToBeQueued, workflow);
             addTaskToQueue(tasksToBeQueued);
         } catch (Exception e) {
             List<String> taskIds =
@@ -1909,7 +1909,7 @@ public class WorkflowExecutor {
         return startedSystemTasks;
     }
 
-    List<TaskModel> getActualTasksToBeQueued(
+    List<TaskModel> getTasksToBeQueued(
             List<TaskModel> tasksToBeQueued, WorkflowModel workflowModel) {
         /* Logic is find out the tasks to be queued in order of execution.
         // If the task that gets reset is completed earlier then the tasks to be executed then

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1894,6 +1894,7 @@ public class WorkflowExecutor {
         // On addTaskToQueue failures, ignore the exceptions and let WorkflowRepairService take care
         // of republishing the messages to the queue.
         try {
+            tasksToBeQueued = getActualTasksToBeQueued(tasksToBeQueued, workflow);
             addTaskToQueue(tasksToBeQueued);
         } catch (Exception e) {
             List<String> taskIds =
@@ -1906,6 +1907,180 @@ public class WorkflowExecutor {
             Monitors.error(CLASS_NAME, "scheduleTask");
         }
         return startedSystemTasks;
+    }
+
+    List<TaskModel> getActualTasksToBeQueued(
+            List<TaskModel> tasksToBeQueued, WorkflowModel workflowModel) {
+        /* Logic is find out the tasks to be queued in order of execution.
+        // If the task that gets reset is completed earlier then the tasks to be executed then
+        // it will get scheduled and tasks which were there in the queue will be removed.
+        // Follow below table for understanding purpose.
+        // Consider workflow t1->t2->t3->t4->t5
+        | Task Completed | Task scheduled | Task reset    | Final output                  |
+        | t1,t2,t3       |    t4          |    t2         |  t2 scheduled, t4 removed     |
+        | t1,t2,t3       |    t4          |    t2,t3      |  t2 scheduled, t4 removed     |
+        | t1,[t2, t3],t4 |    t4          |    t2,t3      |  t2, t3 scheduled, t4 removed |
+        * [] represents tasks are part of fork.
+        */
+        if (!tasksToBeQueued.isEmpty()) {
+            List<TaskModel> scheduledTasks =
+                    workflowModel.getTasks().stream()
+                            .filter(taskModel -> taskModel.getStatus().equals(SCHEDULED))
+                            .collect(Collectors.toList());
+            Map<String, Integer> refNameToSequenceNumber = new HashMap<>();
+            for (TaskModel taskModel : workflowModel.getTasks()) {
+                String taskReferenceName =
+                        TaskUtils.removeIterationFromTaskRefName(taskModel.getReferenceTaskName());
+                if (refNameToSequenceNumber.get(taskReferenceName) == null) {
+                    refNameToSequenceNumber.put(taskReferenceName, taskModel.getSeq());
+                } else if (refNameToSequenceNumber.get(taskReferenceName) > taskModel.getSeq()) {
+                    refNameToSequenceNumber.put(taskReferenceName, taskModel.getSeq());
+                }
+            }
+            // Find the task with the smallest sequence number. sorting is needed in case reset task
+            // are sent unordered
+            tasksToBeQueued.sort(
+                    Comparator.comparingInt(
+                            task ->
+                                    refNameToSequenceNumber.get(
+                                            TaskUtils.removeIterationFromTaskRefName(
+                                                    task.getReferenceTaskName()))));
+            TaskModel smallest = tasksToBeQueued.get(0);
+            // Find the parent of this task if it is fork then get all siblings and scheduled
+            // uncompleted
+            TaskModel parent = getParent(smallest, workflowModel);
+            if (parent == null) {
+                // Task is not part of any fork or dynamic fork
+                // Schedule only smallest task and remove all scheduled tasks from the queue.
+                List<TaskModel> finalTasksToBeQueued = Arrays.asList(smallest);
+                scheduledTasks.stream()
+                        .filter(scheduledTask -> !finalTasksToBeQueued.contains(scheduledTask))
+                        .forEach(
+                                taskModel ->
+                                        queueDAO.remove(
+                                                QueueUtils.getQueueName(taskModel),
+                                                taskModel.getTaskId()));
+                return finalTasksToBeQueued;
+            } else if (parent.getTaskType().equals(TaskType.TASK_TYPE_FORK)
+                    || parent.getTaskType().equals(TaskType.TASK_TYPE_FORK_JOIN)) {
+                // Find sibling from tasksToBeQueued and schedule all of them if they are part of
+                // reset tasks.
+                Set<TaskModel> finalTasksToBeQueued = new HashSet<>();
+                finalTasksToBeQueued.add(smallest);
+                // The parent fork can be inside another fork. So populate all tasks till parent
+                // becomes null.
+                while (parent != null) {
+                    TaskModel finalParent = parent;
+                    tasksToBeQueued.forEach(
+                            taskModel -> {
+                                String childTaskReferenceName =
+                                        TaskUtils.removeIterationFromTaskRefName(
+                                                taskModel.getReferenceTaskName());
+                                if (finalParent.getWorkflowTask() != null
+                                        && finalParent
+                                        .getWorkflowTask()
+                                        .has(childTaskReferenceName)) {
+                                    finalTasksToBeQueued.add(taskModel);
+                                } else if (isTaskInsideDynamicFork(finalParent, taskModel)) {
+                                    finalTasksToBeQueued.add(taskModel);
+                                }
+                            });
+                    scheduledTasks.forEach(
+                            taskModel -> {
+                                String childTaskReferenceName =
+                                        TaskUtils.removeIterationFromTaskRefName(
+                                                taskModel.getReferenceTaskName());
+                                if (finalParent.getWorkflowTask() != null
+                                        && finalParent
+                                        .getWorkflowTask()
+                                        .has(childTaskReferenceName)) {
+                                    finalTasksToBeQueued.add(taskModel);
+                                } else if (isTaskInsideDynamicFork(finalParent, taskModel)) {
+                                    finalTasksToBeQueued.add(taskModel);
+                                }
+                            });
+                    parent = getParent(parent, workflowModel);
+                }
+                // Remove scheduled tasks from the queue if they are not going to fet scheduled
+                scheduledTasks.stream()
+                        .filter(scheduledTask -> !finalTasksToBeQueued.contains(scheduledTask))
+                        .forEach(
+                                taskModel ->
+                                        queueDAO.remove(
+                                                QueueUtils.getQueueName(taskModel),
+                                                taskModel.getTaskId()));
+                return new ArrayList<>(finalTasksToBeQueued);
+            }
+            return tasksToBeQueued;
+        }
+        return tasksToBeQueued;
+    }
+
+    // Get parent of any task. Returns null if parent does not exist.
+    private TaskModel getParent(TaskModel child, WorkflowModel workflowModel) {
+        List<TaskModel> allTasks = workflowModel.getTasks();
+        TaskModel parent = null;
+        for (TaskModel taskModel : allTasks) {
+            String childTaskReferenceName =
+                    TaskUtils.removeIterationFromTaskRefName(child.getReferenceTaskName());
+            String parentTaskReferenceName =
+                    TaskUtils.removeIterationFromTaskRefName(taskModel.getReferenceTaskName());
+            if (taskModel.getWorkflowTask() != null
+                    && taskModel.getWorkflowTask().has(childTaskReferenceName)
+                    && !childTaskReferenceName.equals(parentTaskReferenceName)) {
+                parent = taskModel;
+            } else if (isTaskInsideDynamicFork(taskModel, child)) {
+                parent = taskModel;
+            }
+        }
+        return parent;
+    }
+
+    private boolean isTaskInsideDynamicFork(TaskModel taskModel, TaskModel smallest) {
+        if (taskModel.getWorkflowTask() != null
+                && taskModel.getWorkflowTask().getType() != null
+                && taskModel
+                .getWorkflowTask()
+                .getType()
+                .equals(TaskType.TASK_TYPE_FORK_JOIN_DYNAMIC)) {
+            // Check task is a part of dynamic fork input
+            String childTaskReferenceName =
+                    TaskUtils.removeIterationFromTaskRefName(smallest.getReferenceTaskName());
+            if (taskModel.getInputData().get("forkedTasks") != null
+                    && taskModel.getInputData().get("forkedTasks") instanceof List) {
+                List<String> taskNames = (List) taskModel.getInputData().get("forkedTasks");
+                return taskNames.contains(childTaskReferenceName);
+            }
+        }
+        return false;
+    }
+
+    public void retryTaskForRunningWorkflow(WorkflowModel workflow, List<String> taskIds) {
+        workflow.setStatus(WorkflowModel.Status.RUNNING);
+        workflow.setLastRetriedTime(System.currentTimeMillis());
+        // Add to decider queue
+        queueDAO.push(
+                DECIDER_QUEUE,
+                workflow.getWorkflowId(),
+                workflow.getPriority(),
+                properties.getWorkflowOffsetTimeout().getSeconds());
+        executionDAOFacade.updateWorkflow(workflow);
+
+        // taskToBeRescheduled would set task `retried` to true, and hence it's important to
+        // updateTasks after obtaining task copy from taskToBeRescheduled.
+        final WorkflowModel finalWorkflow = workflow;
+        List<TaskModel> retriableMap =
+                taskIds.stream().map(executionDAOFacade::getTaskModel).collect(Collectors.toList());
+        List<TaskModel> retriableTasks =
+                retriableMap.stream()
+                        .map(task -> taskToBeRescheduled(finalWorkflow, task))
+                        .collect(Collectors.toList());
+
+        dedupAndAddTasks(workflow, retriableTasks);
+        // Note: updateTasks before updateWorkflow might fail when Workflow is archived and doesn't
+        // exist in primary store.
+        executionDAOFacade.updateTasks(workflow.getTasks());
+        scheduleTask(workflow, retriableTasks);
     }
 
     private void addTaskToQueue(final List<TaskModel> tasks) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1978,8 +1978,8 @@ public class WorkflowExecutor {
                                                 taskModel.getReferenceTaskName());
                                 if (finalParent.getWorkflowTask() != null
                                         && finalParent
-                                        .getWorkflowTask()
-                                        .has(childTaskReferenceName)) {
+                                                .getWorkflowTask()
+                                                .has(childTaskReferenceName)) {
                                     finalTasksToBeQueued.add(taskModel);
                                 } else if (isTaskInsideDynamicFork(finalParent, taskModel)) {
                                     finalTasksToBeQueued.add(taskModel);
@@ -1992,8 +1992,8 @@ public class WorkflowExecutor {
                                                 taskModel.getReferenceTaskName());
                                 if (finalParent.getWorkflowTask() != null
                                         && finalParent
-                                        .getWorkflowTask()
-                                        .has(childTaskReferenceName)) {
+                                                .getWorkflowTask()
+                                                .has(childTaskReferenceName)) {
                                     finalTasksToBeQueued.add(taskModel);
                                 } else if (isTaskInsideDynamicFork(finalParent, taskModel)) {
                                     finalTasksToBeQueued.add(taskModel);
@@ -2040,9 +2040,9 @@ public class WorkflowExecutor {
         if (taskModel.getWorkflowTask() != null
                 && taskModel.getWorkflowTask().getType() != null
                 && taskModel
-                .getWorkflowTask()
-                .getType()
-                .equals(TaskType.TASK_TYPE_FORK_JOIN_DYNAMIC)) {
+                        .getWorkflowTask()
+                        .getType()
+                        .equals(TaskType.TASK_TYPE_FORK_JOIN_DYNAMIC)) {
             // Check task is a part of dynamic fork input
             String childTaskReferenceName =
                     TaskUtils.removeIterationFromTaskRefName(smallest.getReferenceTaskName());

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -434,4 +434,12 @@ public interface WorkflowService {
      */
     ExternalStorageLocation getExternalStorageLocation(
             String path, String operation, String payloadType);
+
+    /**
+     * Reset tasks in the workflow
+     *
+     * @param workflowId  workflowId
+     * @param taskIds List of taskIds to be reset
+     */
+    void resetTasks(String workflowId, List<String> taskIds);
 }

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowService.java
@@ -438,7 +438,7 @@ public interface WorkflowService {
     /**
      * Reset tasks in the workflow
      *
-     * @param workflowId  workflowId
+     * @param workflowId workflowId
      * @param taskIds List of taskIds to be reset
      */
     void resetTasks(String workflowId, List<String> taskIds);

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -19,9 +19,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.netflix.conductor.core.dal.ExecutionDAOFacade;
-import com.netflix.conductor.model.TaskModel;
-import com.netflix.conductor.model.WorkflowModel;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,9 +35,12 @@ import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.exception.ApplicationException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.utils.Utils;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.model.WorkflowModel;
 
 @Audit
 @Trace
@@ -620,14 +620,17 @@ public class WorkflowServiceImpl implements WorkflowService {
                 taskId -> {
                     TaskModel task = taskIdMap.get(taskId);
                     if (task == null) {
-                        throw new ApplicationException(ApplicationException.Code.NOT_FOUND,
+                        throw new ApplicationException(
+                                ApplicationException.Code.NOT_FOUND,
                                 "Task with id "
                                         + taskId
                                         + " does not exist in the workflow "
                                         + workflowId);
                     }
                     if (!task.getStatus().isTerminal()) {
-                        throw new ApplicationException(ApplicationException.Code.CONFLICT, "Can not reset non terminal task " + taskId);
+                        throw new ApplicationException(
+                                ApplicationException.Code.CONFLICT,
+                                "Can not reset non terminal task " + taskId);
                     }
                     task.setStatus(TaskModel.Status.SCHEDULED);
                 });

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -233,7 +233,7 @@ public class TestDeciderOutcomes {
         workflow.getTasks().addAll(outcome.tasksToBeScheduled);
         outcome = deciderService.decide(workflow);
         assertFalse(outcome.isComplete);
-        assertEquals(outcome.tasksToBeUpdated.toString(), 1, outcome.tasksToBeUpdated.size());
+        assertEquals(outcome.tasksToBeUpdated.toString(), 3, outcome.tasksToBeUpdated.size());
         assertEquals(1, outcome.tasksToBeScheduled.size());
         assertEquals("junit_task_3", outcome.tasksToBeScheduled.get(0).getTaskDefName());
     }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -17,6 +17,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -2479,5 +2480,265 @@ public class TestWorkflowExecutor {
         }
 
         return tasks;
+    }
+
+    @Test
+    public void testScheduleTask1() {
+        // T1 and T2 get reset and no task scheduled in the workflow.
+        TaskModel taskModel1 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.COMPLETED, 1);
+        TaskModel taskModel2 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.COMPLETED, 2);
+        TaskModel taskModel3 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.COMPLETED, 3);
+        WorkflowModel workflowModel =
+                getWorkflow(Arrays.asList(taskModel1, taskModel2, taskModel3));
+
+        TaskModel taskModel11 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.SCHEDULED, 4);
+        TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
+
+        List<TaskModel> taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel11, taskModel22), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 1);
+        Assert.assertEquals(taskModels.get(0).getReferenceTaskName(), "t1");
+        verify(queueDAO, times(0)).remove(anyString(), anyString());
+    }
+
+    @Test
+    public void testScheduleTask2() {
+        // T1 and T2 get reset and T4 is scheduled in the workflow.
+        TaskModel taskModel1 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.COMPLETED, 1);
+        TaskModel taskModel2 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.COMPLETED, 2);
+        TaskModel taskModel3 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.COMPLETED, 3);
+        TaskModel taskModel4 = getTaskModel("t4", SIMPLE.name(), TaskModel.Status.SCHEDULED, 4);
+        WorkflowModel workflowModel =
+                getWorkflow(Arrays.asList(taskModel1, taskModel2, taskModel3, taskModel4));
+
+        TaskModel taskModel11 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
+        TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 6);
+
+        List<TaskModel> taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel11, taskModel22), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 1);
+        Assert.assertEquals(taskModels.get(0).getReferenceTaskName(), "t1");
+        verify(queueDAO, times(1)).remove(anyString(), anyString());
+    }
+
+    @Test
+    public void testScheduleTask3() {
+        // T2 and T3 get reset and at same level (part of fork) and no task is scheduled in the
+        // workflow.
+        TaskModel taskModel1 = getTaskModel("t1", FORK_JOIN.name(), TaskModel.Status.COMPLETED, 1);
+        TaskModel taskModel2 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.COMPLETED, 2);
+        TaskModel taskModel3 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.COMPLETED, 3);
+        taskModel1
+                .getWorkflowTask()
+                .getForkTasks()
+                .add(Arrays.asList(taskModel3.getWorkflowTask(), taskModel2.getWorkflowTask()));
+        TaskModel taskModel4 = getTaskModel("t4", JOIN.name(), TaskModel.Status.COMPLETED, 4);
+        WorkflowModel workflowModel =
+                getForkWorkflow(Arrays.asList(taskModel1, taskModel2, taskModel3, taskModel4));
+
+        TaskModel taskModel11 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
+        TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 6);
+
+        List<TaskModel> taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel11, taskModel22), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 2);
+        Assert.assertTrue(
+                taskModels.stream()
+                        .anyMatch(taskModel -> "t2".equals(taskModel.getReferenceTaskName())));
+        Assert.assertTrue(
+                taskModels.stream()
+                        .anyMatch(taskModel -> "t3".equals(taskModel.getReferenceTaskName())));
+        verify(queueDAO, times(0)).remove(anyString(), anyString());
+    }
+
+    @Test
+    public void testScheduleTask4() {
+        // T2 and T3 get reset and at same level (part of fork) and T5 is scheduled in the workflow.
+        TaskModel taskModel1 = getTaskModel("t1", FORK_JOIN.name(), TaskModel.Status.COMPLETED, 1);
+        TaskModel taskModel2 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.COMPLETED, 2);
+        TaskModel taskModel3 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.COMPLETED, 3);
+        taskModel1
+                .getWorkflowTask()
+                .getForkTasks()
+                .add(Arrays.asList(taskModel3.getWorkflowTask(), taskModel2.getWorkflowTask()));
+        TaskModel taskModel4 = getTaskModel("t4", JOIN.name(), TaskModel.Status.COMPLETED, 4);
+        TaskModel taskModel5 = getTaskModel("t5", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
+        WorkflowModel workflowModel =
+                getForkWorkflow(
+                        Arrays.asList(taskModel1, taskModel2, taskModel3, taskModel4, taskModel5));
+
+        TaskModel taskModel11 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.SCHEDULED, 6);
+        TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 7);
+
+        List<TaskModel> taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel11, taskModel22), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 2);
+        Assert.assertTrue(
+                taskModels.stream()
+                        .anyMatch(taskModel -> "t2".equals(taskModel.getReferenceTaskName())));
+        Assert.assertTrue(
+                taskModels.stream()
+                        .anyMatch(taskModel -> "t3".equals(taskModel.getReferenceTaskName())));
+        verify(queueDAO, times(1)).remove(anyString(), anyString());
+    }
+
+    @Test
+    public void testScheduleTask5() {
+        // T3 get reset and T4 is scheduled in the workflow.
+        // T2 got reset after that so T2 should get chance.
+        TaskModel taskModel1 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.COMPLETED, 1);
+        TaskModel taskModel2 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.COMPLETED, 2);
+        TaskModel taskModel3 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.COMPLETED, 3);
+        TaskModel taskModel4 = getTaskModel("t4", SIMPLE.name(), TaskModel.Status.SCHEDULED, 4);
+        WorkflowModel workflowModel =
+                getWorkflow(Arrays.asList(taskModel1, taskModel2, taskModel3, taskModel4));
+
+        TaskModel taskModel11 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
+
+        List<TaskModel> taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel11), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 1);
+        Assert.assertEquals(taskModels.get(0).getReferenceTaskName(), "t3");
+        // Now T2 got reset so T3 (given it is still scheduled and worker has not polled) should be
+        // removed from queue
+        // and T2 should get chance
+        TaskModel taskModel22 = new TaskModel();
+        taskModel22.setReferenceTaskName("t2");
+        taskModel22.setTaskType(SIMPLE.name());
+        taskModel22.setStatus(TaskModel.Status.SCHEDULED);
+        taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel22), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 1);
+        Assert.assertEquals(taskModels.get(0).getReferenceTaskName(), "t2");
+        verify(queueDAO, times(2)).remove(anyString(), anyString());
+    }
+
+    @Test
+    public void testScheduleTask6() {
+        // T2 get reset at same level and T3 is scheduled in the workflow. so T2 and T3 both
+        // scheduled.
+        // T1 got reset after that so T1 should get chance. and T2 and T3 should get removed.
+        TaskModel taskModel1 = getTaskModel("t1", FORK_JOIN.name(), TaskModel.Status.COMPLETED, 1);
+        TaskModel taskModel2 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.COMPLETED, 2);
+        TaskModel taskModel3 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.COMPLETED, 3);
+        taskModel1
+                .getWorkflowTask()
+                .getForkTasks()
+                .add(Arrays.asList(taskModel3.getWorkflowTask(), taskModel2.getWorkflowTask()));
+        TaskModel taskModel4 = getTaskModel("t4", JOIN.name(), TaskModel.Status.COMPLETED, 4);
+        WorkflowModel workflowModel =
+                getForkWorkflow(Arrays.asList(taskModel1, taskModel2, taskModel3, taskModel4));
+
+        TaskModel taskModel11 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
+        TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 6);
+
+        List<TaskModel> taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel11, taskModel22), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 2);
+        Assert.assertTrue(
+                taskModels.stream()
+                        .anyMatch(taskModel -> "t2".equals(taskModel.getReferenceTaskName())));
+        Assert.assertTrue(
+                taskModels.stream()
+                        .anyMatch(taskModel -> "t3".equals(taskModel.getReferenceTaskName())));
+
+        // Now T1 got reset, it should get chance and T2 and t3 should be removed from the queue.
+        TaskModel taskModel21 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.SCHEDULED, 7);
+        taskModels =
+                workflowExecutor.getActualTasksToBeQueued(
+                        Arrays.asList(taskModel21), workflowModel);
+
+        Assert.assertEquals(taskModels.size(), 1);
+        Assert.assertTrue(
+                taskModels.stream()
+                        .anyMatch(taskModel -> "t1".equals(taskModel.getReferenceTaskName())));
+        verify(queueDAO, times(0)).remove(anyString(), anyString());
+    }
+
+    private TaskModel getTaskModel(
+            String name, String type, TaskModel.Status status, int sequenceNumber) {
+        TaskModel taskModel = new TaskModel();
+        taskModel.setReferenceTaskName(name);
+        taskModel.setTaskType(type);
+        taskModel.setStatus(status);
+        taskModel.setSeq(sequenceNumber);
+        taskModel.setTaskId(UUID.randomUUID().toString());
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setType(type);
+        workflowTask.setName(name);
+        workflowTask.setTaskReferenceName(name);
+        taskModel.setWorkflowTask(workflowTask);
+        return taskModel;
+    }
+
+    private WorkflowTask getWorkflowTask(String name, String type) {
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setName(name);
+        workflowTask.setTaskReferenceName(name);
+        workflowTask.setType(type);
+        return workflowTask;
+    }
+
+    private WorkflowModel getForkWorkflow(List<TaskModel> taskModels) {
+        // setup
+        WorkflowTask t1 = getWorkflowTask("t1", FORK_JOIN.name());
+        WorkflowTask t2 = getWorkflowTask("t2", SIMPLE.name());
+        WorkflowTask t3 = getWorkflowTask("t3", SIMPLE.name());
+        t1.setForkTasks(List.of(Arrays.asList(t2, t3)));
+        WorkflowTask t4 = getWorkflowTask("t4", JOIN.name());
+        WorkflowTask t5 = getWorkflowTask("t5", SIMPLE.name());
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("test_workflow");
+        workflowDef.setVersion(1);
+        workflowDef.setTasks(Arrays.asList(t1, t4, t5));
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("test_workflow");
+        workflow.setWorkflowDefinition(workflowDef);
+        workflow.setOwnerApp("junit_test_workflow");
+        workflow.setCreateTime(10L);
+        workflow.setEndTime(100L);
+        workflow.setTasks(taskModels);
+        workflow.setStatus(WorkflowModel.Status.RUNNING);
+
+        return workflow;
+    }
+
+    private WorkflowModel getWorkflow(List<TaskModel> taskModels) {
+        // setup
+        WorkflowTask t1 = getWorkflowTask("t1", SIMPLE.name());
+        WorkflowTask t2 = getWorkflowTask("t2", SIMPLE.name());
+        WorkflowTask t3 = getWorkflowTask("t3", SIMPLE.name());
+        WorkflowTask t4 = getWorkflowTask("t4", SIMPLE.name());
+        WorkflowTask t5 = getWorkflowTask("t5", SIMPLE.name());
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("test_workflow");
+        workflowDef.setVersion(1);
+        workflowDef.setTasks(Arrays.asList(t1, t2, t3, t4, t5));
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("test_workflow");
+        workflow.setWorkflowDefinition(workflowDef);
+        workflow.setOwnerApp("junit_test_workflow");
+        workflow.setCreateTime(10L);
+        workflow.setEndTime(100L);
+        workflow.setTasks(taskModels);
+        workflow.setStatus(WorkflowModel.Status.RUNNING);
+
+        return workflow;
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -2495,7 +2495,7 @@ public class TestWorkflowExecutor {
         TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
 
         List<TaskModel> taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel11, taskModel22), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);
@@ -2517,7 +2517,7 @@ public class TestWorkflowExecutor {
         TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 6);
 
         List<TaskModel> taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel11, taskModel22), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);
@@ -2544,7 +2544,7 @@ public class TestWorkflowExecutor {
         TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 6);
 
         List<TaskModel> taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel11, taskModel22), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 2);
@@ -2577,7 +2577,7 @@ public class TestWorkflowExecutor {
         TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 7);
 
         List<TaskModel> taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel11, taskModel22), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 2);
@@ -2604,7 +2604,7 @@ public class TestWorkflowExecutor {
         TaskModel taskModel11 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
 
         List<TaskModel> taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel11), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);
@@ -2617,7 +2617,7 @@ public class TestWorkflowExecutor {
         taskModel22.setTaskType(SIMPLE.name());
         taskModel22.setStatus(TaskModel.Status.SCHEDULED);
         taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel22), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);
@@ -2645,7 +2645,7 @@ public class TestWorkflowExecutor {
         TaskModel taskModel22 = getTaskModel("t2", SIMPLE.name(), TaskModel.Status.SCHEDULED, 6);
 
         List<TaskModel> taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel11, taskModel22), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 2);
@@ -2659,7 +2659,7 @@ public class TestWorkflowExecutor {
         // Now T1 got reset, it should get chance and T2 and t3 should be removed from the queue.
         TaskModel taskModel21 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.SCHEDULED, 7);
         taskModels =
-                workflowExecutor.getActualTasksToBeQueued(
+                workflowExecutor.getTasksToBeQueued(
                         Arrays.asList(taskModel21), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -2604,8 +2604,7 @@ public class TestWorkflowExecutor {
         TaskModel taskModel11 = getTaskModel("t3", SIMPLE.name(), TaskModel.Status.SCHEDULED, 5);
 
         List<TaskModel> taskModels =
-                workflowExecutor.getTasksToBeQueued(
-                        Arrays.asList(taskModel11), workflowModel);
+                workflowExecutor.getTasksToBeQueued(Arrays.asList(taskModel11), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);
         Assert.assertEquals(taskModels.get(0).getReferenceTaskName(), "t3");
@@ -2616,9 +2615,7 @@ public class TestWorkflowExecutor {
         taskModel22.setReferenceTaskName("t2");
         taskModel22.setTaskType(SIMPLE.name());
         taskModel22.setStatus(TaskModel.Status.SCHEDULED);
-        taskModels =
-                workflowExecutor.getTasksToBeQueued(
-                        Arrays.asList(taskModel22), workflowModel);
+        taskModels = workflowExecutor.getTasksToBeQueued(Arrays.asList(taskModel22), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);
         Assert.assertEquals(taskModels.get(0).getReferenceTaskName(), "t2");
@@ -2658,9 +2655,7 @@ public class TestWorkflowExecutor {
 
         // Now T1 got reset, it should get chance and T2 and t3 should be removed from the queue.
         TaskModel taskModel21 = getTaskModel("t1", SIMPLE.name(), TaskModel.Status.SCHEDULED, 7);
-        taskModels =
-                workflowExecutor.getTasksToBeQueued(
-                        Arrays.asList(taskModel21), workflowModel);
+        taskModels = workflowExecutor.getTasksToBeQueued(Arrays.asList(taskModel21), workflowModel);
 
         Assert.assertEquals(taskModels.size(), 1);
         Assert.assertTrue(

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -72,6 +72,9 @@ public class WorkflowServiceTest {
         }
 
         @Bean
+        public ExecutionDAOFacade executionDAOFacade() {return mock(ExecutionDAOFacade.class);}
+
+        @Bean
         public WorkflowService workflowService(
                 WorkflowExecutor workflowExecutor,
                 ExecutionService executionService,

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 import javax.validation.ConstraintViolationException;
 
-import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +35,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.exception.ApplicationException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 
@@ -77,7 +77,8 @@ public class WorkflowServiceTest {
                 ExecutionService executionService,
                 ExecutionDAOFacade executionDAOFacade,
                 MetadataService metadataService) {
-            return new WorkflowServiceImpl(workflowExecutor, executionService, executionDAOFacade, metadataService);
+            return new WorkflowServiceImpl(
+                    workflowExecutor, executionService, executionDAOFacade, metadataService);
         }
     }
 

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import javax.validation.ConstraintViolationException;
 
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,8 +75,9 @@ public class WorkflowServiceTest {
         public WorkflowService workflowService(
                 WorkflowExecutor workflowExecutor,
                 ExecutionService executionService,
+                ExecutionDAOFacade executionDAOFacade,
                 MetadataService metadataService) {
-            return new WorkflowServiceImpl(workflowExecutor, executionService, metadataService);
+            return new WorkflowServiceImpl(workflowExecutor, executionService, executionDAOFacade, metadataService);
         }
     }
 

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -72,7 +72,9 @@ public class WorkflowServiceTest {
         }
 
         @Bean
-        public ExecutionDAOFacade executionDAOFacade() {return mock(ExecutionDAOFacade.class);}
+        public ExecutionDAOFacade executionDAOFacade() {
+            return mock(ExecutionDAOFacade.class);
+        }
 
         @Bean
         public WorkflowService workflowService(

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
@@ -274,4 +274,15 @@ public class WorkflowResource {
             @RequestParam("payloadType") String payloadType) {
         return workflowService.getExternalStorageLocation(path, operation, payloadType);
     }
+
+    @PostMapping("/{workflowId}/reset")
+    @Operation(summary = "Resets tasks for a workflow")
+    @ResponseStatus(
+            value = HttpStatus.NO_CONTENT) // for backwards compatibility with 2.x client which
+    // expects a 204 for this request
+    public void resetTasks(
+            @PathVariable("workflowId") String workflowId,
+            @RequestParam(value = "taskIds", required = true) List<String> taskIds) {
+        workflowService.resetTasks(workflowId, taskIds);
+    }
 }


### PR DESCRIPTION
Pull Request type

 Feature
Changes in this PR
Introduced a new feature called reset tasks.
Tasks can be reset and will get executed again. This is like restarting at task level. Multiple tasks can be restarted together. The task which comes first in the schedule will get executed first.
Workflow execution will proceed only when all reset tasks are completed.