### PR TITLE
Allow using TERMINATED as status for TERMINATE task; Make START_WORKFLOW inherit task to domain map from the parent;

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -960,6 +960,13 @@ public class WorkflowExecutor {
                                 workflow,
                                 new TerminateWorkflowException(
                                         reason, workflow.getStatus(), terminateTask.get()));
+            } else if (WorkflowModel.Status.TERMINATED.name().equals(terminationStatus)) {
+                workflow.setStatus(WorkflowModel.Status.TERMINATED);
+                workflow =
+                        terminate(
+                                workflow,
+                                new TerminateWorkflowException(
+                                        reason, workflow.getStatus(), terminateTask.get()));
             } else {
                 workflow.setReasonForIncompletion(reason);
                 workflow = completeWorkflow(workflow);

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/StartWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/StartWorkflow.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.core.execution.tasks;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.validation.Validator;
@@ -56,6 +57,12 @@ public class StartWorkflow extends WorkflowSystemTask {
         StartWorkflowRequest request = getRequest(taskModel);
         if (request == null) {
             return;
+        }
+        if (request.getTaskToDomain() == null || request.getTaskToDomain().isEmpty()) {
+            Map<String, String> workflowTaskToDomainMap = workflow.getTaskToDomain();
+            if (workflowTaskToDomainMap != null) {
+                request.setTaskToDomain(new HashMap<>(workflowTaskToDomainMap));
+            }
         }
 
         // set the correlation id of starter workflow, if its empty in the StartWorkflowRequest

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Terminate.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Terminate.java
@@ -22,8 +22,7 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_TERMINATE;
-import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.COMPLETED;
-import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.FAILED;
+import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.*;
 
 /**
  * Task that can terminate a workflow with a given status and modify the workflow's output with a
@@ -94,7 +93,9 @@ public class Terminate extends WorkflowSystemTask {
     }
 
     public static Boolean validateInputStatus(String status) {
-        return COMPLETED.name().equals(status) || FAILED.name().equals(status);
+        return COMPLETED.name().equals(status)
+                || FAILED.name().equals(status)
+                || TERMINATED.name().equals(status);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Allow using TERMINATED as status for TERMINATE task;
Make START_WORKFLOW inherit task to domain map from the parent;


