### PR TITLE
Fix for task inconsistencies

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraExecutionDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraExecutionDAO.java
@@ -162,6 +162,16 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public Map<String, String> getAllScheduledTask(String workflowId) {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Long removeScheduledTaskMapping(String workflowId, String key) {
+        return 0L;
+    }
+
     /**
      * This is a dummy implementation and this feature is not implemented for Cassandra backed
      * Conductor

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowRepairService.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowRepairService.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.core.reconciliation;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
@@ -91,12 +92,29 @@ public class WorkflowRepairService {
      */
     public boolean verifyAndRepairWorkflow(String workflowId, boolean includeTasks) {
         WorkflowModel workflow = executionDAO.getWorkflow(workflowId, includeTasks);
+        verifyAndRepairInconsistentTaskStates(workflowId);
         AtomicBoolean repaired = new AtomicBoolean(false);
         repaired.set(verifyAndRepairDeciderQueue(workflow));
         if (includeTasks) {
             workflow.getTasks().forEach(task -> repaired.set(verifyAndRepairTask(task)));
         }
         return repaired.get();
+    }
+
+    private void verifyAndRepairInconsistentTaskStates(String workflowId) {
+        // Check for task inconsistencies i.e. task is scheduled but executionDAO does not have it
+        // or
+        // task is in-progress but executionDAO does not have it. This can occur if redis goes down
+        // before writing task
+        // to executionDAO properly.
+
+        Map<String, String> corruptedTasks = executionDAO.getAllScheduledTask(workflowId);
+        corruptedTasks.forEach(
+                (taskReferenceName, taskId) -> {
+                    if (executionDAO.getTask(taskId) == null) {
+                        executionDAO.removeScheduledTaskMapping(workflowId, taskReferenceName);
+                    }
+                });
     }
 
     /** Verify and repair tasks in a workflow. */

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -13,6 +13,7 @@
 package com.netflix.conductor.dao;
 
 import java.util.List;
+import java.util.Map;
 
 import com.netflix.conductor.common.metadata.events.EventExecution;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -36,6 +37,19 @@ public interface ExecutionDAO {
      * @return List of tasks starting from startKey
      */
     List<TaskModel> getTasks(String taskType, String startKey, int count);
+
+    /**
+     * @param workflowId WorkflowId
+     * @return List of scheduled tasks
+     */
+    Map<String, String> getAllScheduledTask(String workflowId);
+
+    /**
+     * @param workflowId WorkflowId
+     * @param key key to remove
+     * @return key is removed or not.
+     */
+    Long removeScheduledTaskMapping(String workflowId, String key);
 
     /**
      * @param tasks tasks to be created

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
@@ -134,6 +134,22 @@ public class RedisExecutionDAO extends BaseDynoDAO
     }
 
     @Override
+    public Map<String, String> getAllScheduledTask(String workflowId) {
+        String key = nsKey(SCHEDULED_TASKS, workflowId);
+        Map<String, String> tasks = jedisProxy.hgetAll(key);
+        if (tasks == null || tasks.size() == 0) {
+            return new HashMap<>();
+        }
+        return tasks;
+    }
+
+    @Override
+    public Long removeScheduledTaskMapping(String workflowId, String key) {
+        String set = nsKey(SCHEDULED_TASKS, workflowId);
+        return jedisProxy.hdel(set, key);
+    }
+
+    @Override
     public List<TaskModel> createTasks(List<TaskModel> tasks) {
 
         List<TaskModel> tasksCreated = new LinkedList<>();


### PR DESCRIPTION
- [X] Bugfix
Changes to fix task-level inconsistencies that can occur during failover scenarios. 
The issue was when the task was getting added to the scheduled task set, if the task is already present then the new task will not get added and the new task will never get scheduled.
Workflow repair service checks for the task that are scheduled or in-progress but the payload does not present in executionDAO. The repair service will clear all such tasks. So that when the sweeper runs and tries to schedule a new task it will get scheduled. The old task will be removed so there are no duplicate tasks getting scheduled.

