### PR TITLE
feat: optional workerId parameter when setting manual task status

### DIFF
--- a/awssqs-event-queue/src/test/java/com/netflix/conductor/sqs/eventqueue/DefaultEventQueueProcessorTest.java
+++ b/awssqs-event-queue/src/test/java/com/netflix/conductor/sqs/eventqueue/DefaultEventQueueProcessorTest.java
@@ -41,7 +41,6 @@ import com.netflix.conductor.model.WorkflowModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.Uninterruptibles;
 
-import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HTTP;
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_WAIT;
 
 import static org.junit.Assert.assertNotNull;

--- a/core/src/main/java/com/netflix/conductor/core/events/queue/DefaultEventQueueProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/queue/DefaultEventQueueProcessor.java
@@ -98,15 +98,20 @@ public class DefaultEventQueueProcessor {
                                 WorkflowModel workflow =
                                         workflowExecutor.getWorkflow(workflowId, true);
 
-                                // fetch the task to mark completed based on the filter parameters user passed.
+                                // fetch the task to mark completed based on the filter parameters
+                                // user passed.
                                 Optional<TaskModel> optionalTaskModel;
                                 Predicate<TaskModel> filter;
-                                Predicate<TaskModel>
-                                        nonTerminal        = (task) -> !task.getStatus().isTerminal(),
-                                        waitTask           = (task) -> task.getTaskType().equals(TASK_TYPE_WAIT),
-                                        matchesTaskId      = (task) -> task.getTaskId().equals(taskId),
-                                        matchesTaskRefName = (task) -> task.getReferenceTaskName().equals(taskRefName),
-                                        matchesWorkerId    = (task) -> task.getWorkerId().equals(workerId);
+                                Predicate<TaskModel> nonTerminal =
+                                        (task) -> !task.getStatus().isTerminal();
+                                Predicate<TaskModel> waitTask =
+                                        (task) -> task.getTaskType().equals(TASK_TYPE_WAIT);
+                                Predicate<TaskModel> matchesTaskId =
+                                        (task) -> task.getTaskId().equals(taskId);
+                                Predicate<TaskModel> matchesTaskRefName =
+                                        (task) -> task.getReferenceTaskName().equals(taskRefName);
+                                Predicate<TaskModel> matchesWorkerId =
+                                        (task) -> task.getWorkerId().equals(workerId);
 
                                 if (StringUtils.isNotEmpty(taskId)) {
                                     filter = nonTerminal.and(matchesTaskId);
@@ -123,13 +128,15 @@ public class DefaultEventQueueProcessor {
                                     if (StringUtils.isEmpty(workerId)) {
                                         filter = nonTerminal.and(matchesTaskRefName);
                                     } else {
-                                        filter = nonTerminal.and(matchesTaskRefName).and(matchesWorkerId);
+                                        filter =
+                                                nonTerminal
+                                                        .and(matchesTaskRefName)
+                                                        .and(matchesWorkerId);
                                     }
                                 }
 
-                                optionalTaskModel = workflow.getTasks().stream()
-                                        .filter(filter)
-                                        .findFirst();
+                                optionalTaskModel =
+                                        workflow.getTasks().stream().filter(filter).findFirst();
 
                                 if (optionalTaskModel.isEmpty()) {
                                     LOGGER.error(
@@ -188,7 +195,11 @@ public class DefaultEventQueueProcessor {
     }
 
     public void updateByTaskRefName(
-            String workflowId, String taskRefName, String workerId, Map<String, Object> output, Status status)
+            String workflowId,
+            String taskRefName,
+            String workerId,
+            Map<String, Object> output,
+            Status status)
             throws Exception {
         Map<String, Object> externalIdMap = new HashMap<>();
         externalIdMap.put("workflowId", workflowId);

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/QueueAdminResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/QueueAdminResource.java
@@ -54,7 +54,8 @@ public class QueueAdminResource {
             @RequestParam("workerId") String workerId,
             @RequestBody Map<String, Object> output)
             throws Exception {
-        defaultEventQueueProcessor.updateByTaskRefName(workflowId, taskRefName, workerId, output, status);
+        defaultEventQueueProcessor.updateByTaskRefName(
+                workflowId, taskRefName, workerId, output, status);
     }
 
     @Operation(summary = "Publish a message in queue to mark a wait task (by taskId) as completed.")

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/QueueAdminResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/QueueAdminResource.java
@@ -14,12 +14,7 @@ package com.netflix.conductor.rest.controllers;
 
 import java.util.Map;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.netflix.conductor.core.events.queue.DefaultEventQueueProcessor;
 import com.netflix.conductor.model.TaskModel.Status;
@@ -56,9 +51,10 @@ public class QueueAdminResource {
             @PathVariable("workflowId") String workflowId,
             @PathVariable("taskRefName") String taskRefName,
             @PathVariable("status") Status status,
+            @RequestParam("workerId") String workerId,
             @RequestBody Map<String, Object> output)
             throws Exception {
-        defaultEventQueueProcessor.updateByTaskRefName(workflowId, taskRefName, output, status);
+        defaultEventQueueProcessor.updateByTaskRefName(workflowId, taskRefName, workerId, output, status);
     }
 
     @Operation(summary = "Publish a message in queue to mark a wait task (by taskId) as completed.")


### PR DESCRIPTION


Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Allows users to pass an optional workerId parameter when manually setting task status.

_Describe the new behavior from this PR, and why it's needed_

Allows users to filter task status updates for particular workers, which can be useful when working with canaries.

Alternatives considered
----

_Describe alternative implementation you have considered_
