### PR TITLE
Create a separate annotation for owner email validation based on default validator from org.apache.bval

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-core"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation "org.junit.vintage:junit-vintage-engine"
 }
 
 /*

--- a/common/src/main/java/com/netflix/conductor/common/constraints/OwnerEmailValidConstraint.java
+++ b/common/src/main/java/com/netflix/conductor/common/constraints/OwnerEmailValidConstraint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.constraints;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+import org.apache.bval.routines.EMailValidationUtils;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Documented
+@Constraint(validatedBy = OwnerEmailValidConstraint.OwnerEmailValidator.class)
+@Target({TYPE, FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OwnerEmailValidConstraint {
+
+    String message() default "ownerEmail cannot be empty";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    class OwnerEmailValidator implements ConstraintValidator<OwnerEmailValidConstraint, String> {
+
+        @Override
+        public void initialize(OwnerEmailValidConstraint constraintAnnotation) {}
+
+        @Override
+        public boolean isValid(String ownerEmail, ConstraintValidatorContext context) {
+            return EMailValidationUtils.isValid(ownerEmail);
+        }
+    }
+}

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -28,6 +27,7 @@ import com.netflix.conductor.annotations.protogen.ProtoEnum;
 import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
+import com.netflix.conductor.common.constraints.OwnerEmailValidConstraint;
 import com.netflix.conductor.common.constraints.TaskTimeoutConstraint;
 import com.netflix.conductor.common.metadata.Auditable;
 
@@ -114,7 +114,7 @@ public class TaskDef extends Auditable {
 
     @ProtoField(id = 18)
     @OwnerEmailMandatoryConstraint
-    @Email(message = "ownerEmail should be valid email address")
+    @OwnerEmailValidConstraint(message = "ownerEmail should be valid email address")
     private String ownerEmail;
 
     @ProtoField(id = 19)

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -15,7 +15,6 @@ package com.netflix.conductor.common.metadata.workflow;
 import java.util.*;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
@@ -26,6 +25,7 @@ import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 import com.netflix.conductor.common.constraints.NoSemiColonConstraint;
 import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
+import com.netflix.conductor.common.constraints.OwnerEmailValidConstraint;
 import com.netflix.conductor.common.constraints.TaskReferenceNameUniqueConstraint;
 import com.netflix.conductor.common.metadata.Auditable;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
@@ -80,7 +80,7 @@ public class WorkflowDef extends Auditable {
 
     @ProtoField(id = 11)
     @OwnerEmailMandatoryConstraint
-    @Email(message = "ownerEmail should be valid email address")
+    @OwnerEmailValidConstraint(message = "ownerEmail should be valid email address")
     private String ownerEmail;
 
     @ProtoField(id = 12)

--- a/common/src/test/java/com/netflix/conductor/common/tasks/TaskTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/tasks/TaskTest.java
@@ -98,7 +98,7 @@ public class TaskTest {
         final Task task = new Task();
         // In order to avoid forgetting putting inside the copy method the newly added fields check
         // the number of declared fields.
-        final int expectedTaskFieldsNumber = 40;
+        final int expectedTaskFieldsNumber = 41;
         final int declaredFieldsNumber = task.getClass().getDeclaredFields().length;
 
         assertEquals(expectedTaskFieldsNumber, declaredFieldsNumber);


### PR DESCRIPTION
Pull Request type
----
- [x] Refactoring (no functional changes, no api changes)

Changes in this PR
----
Use the validation currently triggered by `@Email` from org.apache.bval.apache.bval.routines.EMailValidationUtils so that the validator can be overridable in forks. As a result the default behaviour should stay the same (empty email, null = still valid)
Enable tests in conductor-common.

Alternatives considered
----

- Apache commons validator library;
- Hard-coded regexps from RFC 822 and RFC 5322;
- Complete removal of the `@Email` constraint.