### PR TITLE
Dynamic inline workflow def suboworfklow

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
@@ -41,13 +41,12 @@ public class SubWorkflowParams {
      * @return the name
      */
     public String getName() {
-        if (workflowDefinition == null) {
-            return name;
-        } else {
+        if (workflowDefinition != null) {
             if (workflowDefinition instanceof WorkflowDef) {
                 return ((WorkflowDef) workflowDefinition).getName();
-            } else return name;
+            }
         }
+        return name;
     }
 
     /**
@@ -61,11 +60,12 @@ public class SubWorkflowParams {
      * @return the version
      */
     public Integer getVersion() {
-        if (this.workflowDefinition != null) {
-            return null;
-        } else {
-            return version;
+        if (workflowDefinition != null) {
+            if (workflowDefinition instanceof WorkflowDef) {
+                return ((WorkflowDef) workflowDefinition).getVersion();
+            }
         }
+        return version;
     }
 
     /**

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
@@ -41,11 +41,11 @@ public class SubWorkflowParams {
      * @return the name
      */
     public String getName() {
-        if(workflowDefinition == null) {
+        if (workflowDefinition == null) {
             return name;
         } else {
-            if(workflowDefinition instanceof WorkflowDef) {
-                return ((WorkflowDef)workflowDefinition).getName();
+            if (workflowDefinition instanceof WorkflowDef) {
+                return ((WorkflowDef) workflowDefinition).getName();
             } else return name;
         }
     }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
@@ -41,10 +41,12 @@ public class SubWorkflowParams {
      * @return the name
      */
     public String getName() {
-        if (this.workflowDefinition != null) {
-            return "ignored";
-        } else {
+        if(workflowDefinition == null) {
             return name;
+        } else {
+            if(workflowDefinition instanceof WorkflowDef) {
+                return ((WorkflowDef)workflowDefinition).getName();
+            } else return name;
         }
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
@@ -21,7 +21,6 @@ import javax.validation.constraints.NotNull;
 import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 @ProtoMessage
@@ -47,7 +46,7 @@ public class SubWorkflowParams {
      * @return the name
      */
     public String getName() {
-        if(this.workflowDefinition != null) {
+        if (this.workflowDefinition != null) {
             return null;
         } else {
             return name;
@@ -65,7 +64,7 @@ public class SubWorkflowParams {
      * @return the version
      */
     public Integer getVersion() {
-        if(this.workflowDefinition != null) {
+        if (this.workflowDefinition != null) {
             return null;
         } else {
             return version;
@@ -104,9 +103,11 @@ public class SubWorkflowParams {
      * @param workflowDef the workflowDefinition to set
      */
     public void setWorkflowDefinition(Object workflowDef) {
-        if (workflowDef != null && !(workflowDef instanceof WorkflowDef)
-                && !(workflowDef instanceof String && !(((String) workflowDef).startsWith("${"))
-                && !(((String) workflowDef).endsWith("}")))) {
+        if (workflowDef != null
+                && !(workflowDef instanceof WorkflowDef)
+                && !(workflowDef instanceof String
+                        && !(((String) workflowDef).startsWith("${"))
+                        && !(((String) workflowDef).endsWith("}")))) {
             throw new IllegalArgumentException(
                     "workflowDefinition must be either null or WorkflowDef");
         }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/SubWorkflowParams.java
@@ -47,8 +47,8 @@ public class SubWorkflowParams {
      * @return the name
      */
     public String getName() {
-        if (workflowDefinition != null) {
-            return getWorkflowDef().getName();
+        if(this.workflowDefinition != null) {
+            return null;
         } else {
             return name;
         }
@@ -65,8 +65,8 @@ public class SubWorkflowParams {
      * @return the version
      */
     public Integer getVersion() {
-        if (workflowDefinition != null) {
-            return getWorkflowDef().getVersion();
+        if(this.workflowDefinition != null) {
+            return null;
         } else {
             return version;
         }
@@ -101,18 +101,12 @@ public class SubWorkflowParams {
     }
 
     /**
-     * @return the workflowDefinition as a WorkflowDef
-     */
-    @JsonGetter("workflowDefinition")
-    public WorkflowDef getWorkflowDef() {
-        return (WorkflowDef) workflowDefinition;
-    }
-
-    /**
      * @param workflowDef the workflowDefinition to set
      */
     public void setWorkflowDefinition(Object workflowDef) {
-        if (!(workflowDef == null || workflowDef instanceof WorkflowDef)) {
+        if (workflowDef != null && !(workflowDef instanceof WorkflowDef)
+                && !(workflowDef instanceof String && !(((String) workflowDef).startsWith("${"))
+                && !(((String) workflowDef).endsWith("}")))) {
             throw new IllegalArgumentException(
                     "workflowDefinition must be either null or WorkflowDef");
         }
@@ -123,7 +117,7 @@ public class SubWorkflowParams {
      * @param workflowDef the workflowDefinition to set
      */
     @JsonSetter("workflowDefinition")
-    public void setWorkflowDef(WorkflowDef workflowDef) {
+    public void setWorkflowDef(Object workflowDef) {
         this.workflowDefinition = workflowDef;
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -25,6 +25,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.PositiveOrZero;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -400,6 +402,10 @@ public class WorkflowTask {
      * @param subWorkflow the subWorkflowParam to set
      */
     public void setSubWorkflowParam(SubWorkflowParams subWorkflow) {
+        if (subWorkflow.getWorkflowDefinition() == null
+                && (StringUtils.isBlank(subWorkflow.getName()))) {
+            throw new IllegalArgumentException("SubWorkflowParams name cannot be null or empty");
+        }
         this.subWorkflowParam = subWorkflow;
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
@@ -12,7 +12,14 @@
  */
 package com.netflix.conductor.common.utils;
 
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class TaskUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final String LOOP_TASK_DELIMITER = "__";
 
@@ -27,5 +34,9 @@ public class TaskUtils {
     public static String removeIterationFromTaskRefName(String referenceTaskName) {
         String[] tokens = referenceTaskName.split(TaskUtils.LOOP_TASK_DELIMITER);
         return tokens.length > 0 ? tokens[0] : referenceTaskName;
+    }
+
+    public static WorkflowDef convertToWorkflowDef(Object workflowDef) {
+        return objectMapper.convertValue(workflowDef, new TypeReference<WorkflowDef>() {});
     }
 }

--- a/common/src/test/java/com/netflix/conductor/common/workflow/SubWorkflowParamsTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/SubWorkflowParamsTest.java
@@ -12,16 +12,8 @@
  */
 package com.netflix.conductor.common.workflow;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +31,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration(classes = {TestObjectMapperConfiguration.class})
 @RunWith(SpringRunner.class)
@@ -47,20 +38,12 @@ public class SubWorkflowParamsTest {
 
     @Autowired private ObjectMapper objectMapper;
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWorkflowTaskName() {
-        SubWorkflowParams subWorkflowParams = new SubWorkflowParams(); // name is null
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        Validator validator = factory.getValidator();
-
-        Set<ConstraintViolation<Object>> result = validator.validate(subWorkflowParams);
-        assertEquals(2, result.size());
-
-        List<String> validationErrors = new ArrayList<>();
-        result.forEach(e -> validationErrors.add(e.getMessage()));
-
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be null"));
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be empty"));
+        WorkflowTask t = new WorkflowTask();
+        SubWorkflowParams subWorkflowParams =
+                new SubWorkflowParams(); // name is null, definition is null
+        t.setSubWorkflowParam(subWorkflowParams);
     }
 
     @Test
@@ -92,7 +75,6 @@ public class SubWorkflowParamsTest {
         def.getTasks().add(task);
         subWorkflowParams.setWorkflowDefinition(def);
         assertEquals(def, subWorkflowParams.getWorkflowDefinition());
-        assertEquals(def, subWorkflowParams.getWorkflowDef());
     }
 
     @Test
@@ -116,7 +98,7 @@ public class SubWorkflowParamsTest {
                 objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(subWorkflowParams);
         SubWorkflowParams deserializedParams =
                 objectMapper.readValue(serializedParams, SubWorkflowParams.class);
-        assertEquals(def, deserializedParams.getWorkflowDefinition());
-        assertEquals(def, deserializedParams.getWorkflowDef());
+        var x = (WorkflowDef) deserializedParams.getWorkflowDefinition();
+        assertEquals(def, x);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -63,8 +63,13 @@ public class SubWorkflowTaskMapper implements TaskMapper {
         Map<String, Object> resolvedParams =
                 getSubWorkflowInputParameters(workflowModel, subWorkflowParams);
 
-        String subWorkflowName = resolvedParams.get("name").toString();
-        Integer subWorkflowVersion = getSubWorkflowVersion(resolvedParams, subWorkflowName);
+        String subWorkflowName = Optional.ofNullable(resolvedParams.get("name"))
+                .map(Object::toString)
+                .orElse(null);
+        Integer subWorkflowVersion = null;
+        if(subWorkflowParams.getWorkflowDefinition() == null && subWorkflowName != null) {
+            subWorkflowVersion = getSubWorkflowVersion(resolvedParams, subWorkflowName);
+        }
 
         Object subWorkflowDefinition = resolvedParams.get("workflowDefinition");
 
@@ -105,7 +110,9 @@ public class SubWorkflowTaskMapper implements TaskMapper {
     private Map<String, Object> getSubWorkflowInputParameters(
             WorkflowModel workflowModel, SubWorkflowParams subWorkflowParams) {
         Map<String, Object> params = new HashMap<>();
-        params.put("name", subWorkflowParams.getName());
+        if(subWorkflowParams.getName() != null) {
+            params.put("name", subWorkflowParams.getName());
+        }
 
         Integer version = subWorkflowParams.getVersion();
         if (version != null) {
@@ -116,12 +123,15 @@ public class SubWorkflowTaskMapper implements TaskMapper {
             params.put("taskToDomain", taskToDomain);
         }
 
-        params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
-
-        // do not resolve params inside subworkflow definition
-        Object subWorkflowDefinition = subWorkflowParams.getWorkflowDefinition();
-        if (subWorkflowDefinition != null) {
-            params.put("workflowDefinition", subWorkflowDefinition);
+        if(subWorkflowParams.getWorkflowDefinition() == null || (subWorkflowParams.getWorkflowDefinition() != null && subWorkflowParams.getWorkflowDefinition() instanceof String)) {
+            params.put("workflowDefinition", subWorkflowParams.getWorkflowDefinition());
+            params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
+        } else {
+            // not DSL but actual workflowDef - do not resolve params inside subworkflow definition
+            Object subWorkflowDefinition = subWorkflowParams.getWorkflowDefinition();
+            if (subWorkflowDefinition != null) {
+                params.put("workflowDefinition", subWorkflowDefinition);
+            }
         }
 
         return params;

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -122,16 +122,13 @@ public class SubWorkflowTaskMapper implements TaskMapper {
             params.put("taskToDomain", taskToDomain);
         }
 
-        if (subWorkflowParams.getWorkflowDefinition() == null
-                || (subWorkflowParams.getWorkflowDefinition() != null
-                        && subWorkflowParams.getWorkflowDefinition() instanceof String)) {
-            params.put("workflowDefinition", subWorkflowParams.getWorkflowDefinition());
-            params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
+        if (subWorkflowParams.getWorkflowDefinition() == null) {
+            params.put("workflowDefinition", null);
         } else {
-            // not DSL but actual workflowDef - do not resolve params inside subworkflow definition
             Object subWorkflowDefinition = subWorkflowParams.getWorkflowDefinition();
-            if (subWorkflowDefinition != null) {
-                params.put("workflowDefinition", subWorkflowDefinition);
+            params.put("workflowDefinition", subWorkflowDefinition);
+            if (subWorkflowDefinition instanceof String) {
+                params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
             }
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -127,7 +127,7 @@ public class SubWorkflowTaskMapper implements TaskMapper {
         } else {
             Object subWorkflowDefinition = subWorkflowParams.getWorkflowDefinition();
             params.put("workflowDefinition", subWorkflowDefinition);
-            if (subWorkflowDefinition instanceof String) {
+            if (subWorkflowDefinition instanceof String) { //DSL string
                 params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
             }
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -63,11 +63,10 @@ public class SubWorkflowTaskMapper implements TaskMapper {
         Map<String, Object> resolvedParams =
                 getSubWorkflowInputParameters(workflowModel, subWorkflowParams);
 
-        String subWorkflowName = Optional.ofNullable(resolvedParams.get("name"))
-                .map(Object::toString)
-                .orElse(null);
+        String subWorkflowName =
+                Optional.ofNullable(resolvedParams.get("name")).map(Object::toString).orElse(null);
         Integer subWorkflowVersion = null;
-        if(subWorkflowParams.getWorkflowDefinition() == null && subWorkflowName != null) {
+        if (subWorkflowParams.getWorkflowDefinition() == null && subWorkflowName != null) {
             subWorkflowVersion = getSubWorkflowVersion(resolvedParams, subWorkflowName);
         }
 
@@ -110,7 +109,7 @@ public class SubWorkflowTaskMapper implements TaskMapper {
     private Map<String, Object> getSubWorkflowInputParameters(
             WorkflowModel workflowModel, SubWorkflowParams subWorkflowParams) {
         Map<String, Object> params = new HashMap<>();
-        if(subWorkflowParams.getName() != null) {
+        if (subWorkflowParams.getName() != null) {
             params.put("name", subWorkflowParams.getName());
         }
 
@@ -123,7 +122,9 @@ public class SubWorkflowTaskMapper implements TaskMapper {
             params.put("taskToDomain", taskToDomain);
         }
 
-        if(subWorkflowParams.getWorkflowDefinition() == null || (subWorkflowParams.getWorkflowDefinition() != null && subWorkflowParams.getWorkflowDefinition() instanceof String)) {
+        if (subWorkflowParams.getWorkflowDefinition() == null
+                || (subWorkflowParams.getWorkflowDefinition() != null
+                        && subWorkflowParams.getWorkflowDefinition() instanceof String)) {
             params.put("workflowDefinition", subWorkflowParams.getWorkflowDefinition());
             params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
         } else {

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -127,7 +127,7 @@ public class SubWorkflowTaskMapper implements TaskMapper {
         } else {
             Object subWorkflowDefinition = subWorkflowParams.getWorkflowDefinition();
             params.put("workflowDefinition", subWorkflowDefinition);
-            if (subWorkflowDefinition instanceof String) { //DSL string
+            if (subWorkflowDefinition instanceof String) { // DSL string
                 params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
             }
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -122,13 +122,17 @@ public class SubWorkflowTaskMapper implements TaskMapper {
             params.put("taskToDomain", taskToDomain);
         }
 
-        params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
         if (subWorkflowParams.getWorkflowDefinition() == null) {
             params.put("workflowDefinition", null);
+            params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
         } else {
             Object subWorkflowDefinition = subWorkflowParams.getWorkflowDefinition();
             if (!(subWorkflowDefinition instanceof String)) { // not a DSL string
+                params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
                 params.put("workflowDefinition", subWorkflowParams.getWorkflowDefinition());
+            } else {
+                params.put("workflowDefinition", subWorkflowParams.getWorkflowDefinition());
+                params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
             }
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SubWorkflowTaskMapper.java
@@ -122,13 +122,13 @@ public class SubWorkflowTaskMapper implements TaskMapper {
             params.put("taskToDomain", taskToDomain);
         }
 
+        params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
         if (subWorkflowParams.getWorkflowDefinition() == null) {
             params.put("workflowDefinition", null);
         } else {
             Object subWorkflowDefinition = subWorkflowParams.getWorkflowDefinition();
-            params.put("workflowDefinition", subWorkflowDefinition);
-            if (subWorkflowDefinition instanceof String) { // DSL string
-                params = parametersUtils.getTaskInputV2(params, workflowModel, null, null);
+            if (!(subWorkflowDefinition instanceof String)) { // not a DSL string
+                params.put("workflowDefinition", subWorkflowParams.getWorkflowDefinition());
             }
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -15,7 +15,6 @@ package com.netflix.conductor.core.execution.tasks;
 import java.util.Map;
 import java.util.Optional;
 
-import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +22,7 @@ import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.exception.ApplicationException;
+import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
@@ -59,10 +59,14 @@ public class SubWorkflow extends WorkflowSystemTask {
                             input.get("subWorkflowDefinition"), WorkflowDef.class);
             name = workflowDefinition.getName();
         } else {
-            name = Optional.ofNullable(input.get("subWorkflowName")).map(Object::toString).orElse(null);
+            name =
+                    Optional.ofNullable(input.get("subWorkflowName"))
+                            .map(Object::toString)
+                            .orElse(null);
             version = (Integer) input.get("subWorkflowVersion");
-            if(name == null) {
-                throw new TerminateWorkflowException("SubWorkflow name is null, but no workflowDefinition supplied");
+            if (name == null) {
+                throw new TerminateWorkflowException(
+                        "SubWorkflow name is null, but no workflowDefinition supplied");
             }
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/metadata/MetadataMapperService.java
+++ b/core/src/main/java/com/netflix/conductor/core/metadata/MetadataMapperService.java
@@ -138,7 +138,8 @@ public class MetadataMapperService {
     private void populateVersionForSubWorkflow(WorkflowTask workflowTask) {
         Utils.checkNotNull(workflowTask, "WorkflowTask cannot be null");
         SubWorkflowParams subworkflowParams = workflowTask.getSubWorkflowParam();
-        if (subworkflowParams.getVersion() == null && subworkflowParams.getWorkflowDefinition() == null) {
+        if (subworkflowParams.getVersion() == null
+                && subworkflowParams.getWorkflowDefinition() == null) {
             String subWorkflowName = subworkflowParams.getName();
             Integer subWorkflowVersion =
                     metadataDAO

--- a/core/src/main/java/com/netflix/conductor/core/metadata/MetadataMapperService.java
+++ b/core/src/main/java/com/netflix/conductor/core/metadata/MetadataMapperService.java
@@ -138,7 +138,7 @@ public class MetadataMapperService {
     private void populateVersionForSubWorkflow(WorkflowTask workflowTask) {
         Utils.checkNotNull(workflowTask, "WorkflowTask cannot be null");
         SubWorkflowParams subworkflowParams = workflowTask.getSubWorkflowParam();
-        if (subworkflowParams.getVersion() == null) {
+        if (subworkflowParams.getVersion() == null && subworkflowParams.getWorkflowDefinition() == null) {
             String subWorkflowName = subworkflowParams.getName();
             Integer subWorkflowVersion =
                     metadataDAO

--- a/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
+++ b/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
@@ -413,23 +413,13 @@ public class WorkflowTaskTypeConstraintTest {
                         "subWorkflowParam field is required for taskType: SUB_WORKFLOW taskName: encode"));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWorkflowTaskTypeSubworkflow() {
         WorkflowTask workflowTask = createSampleWorkflowTask();
         workflowTask.setType("SUB_WORKFLOW");
 
         SubWorkflowParams subWorkflowTask = new SubWorkflowParams();
         workflowTask.setSubWorkflowParam(subWorkflowTask);
-
-        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
-        assertEquals(2, result.size());
-
-        List<String> validationErrors = new ArrayList<>();
-
-        result.forEach(e -> validationErrors.add(e.getMessage()));
-
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be null"));
-        assertTrue(validationErrors.contains("SubWorkflowParams name cannot be empty"));
     }
 
     @Test

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/testing/LocalServerRunner.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/testing/LocalServerRunner.java
@@ -65,6 +65,7 @@ public class LocalServerRunner {
     public String getServerAPIUrl() {
         return this.serverURL + "api/";
     }
+
     /**
      * Starts the local server. Downloads the latest conductor build from the maven repo If you want
      * to start the server from a specific download location, set `repositoryURL` system property

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.sdk.workflow.def.tasks;
 
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.SubWorkflowParams;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.sdk.workflow.def.ConductorWorkflow;
 
@@ -54,9 +55,9 @@ public class SubWorkflow extends Task<SubWorkflow> {
         SubWorkflowParams subworkflowParam = workflowTask.getSubWorkflowParam();
         this.workflowName = subworkflowParam.getName();
         this.workflowVersion = subworkflowParam.getVersion();
-        if (subworkflowParam.getWorkflowDef() != null) {
+        if (subworkflowParam.getWorkflowDefinition() != null && subworkflowParam.getWorkflowDefinition() instanceof WorkflowDef) {
             this.conductorWorkflow =
-                    ConductorWorkflow.fromWorkflowDef(subworkflowParam.getWorkflowDef());
+                    ConductorWorkflow.fromWorkflowDef((WorkflowDef) subworkflowParam.getWorkflowDefinition());
         }
     }
 

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
@@ -80,7 +80,7 @@ public class SubWorkflow extends Task<SubWorkflow> {
         SubWorkflowParams subWorkflowParam = new SubWorkflowParams();
 
         if (conductorWorkflow != null) {
-            subWorkflowParam.setWorkflowDef(conductorWorkflow.toWorkflowDef());
+            subWorkflowParam.setWorkflowDefinition(conductorWorkflow.toWorkflowDef());
         } else {
             subWorkflowParam.setName(workflowName);
             subWorkflowParam.setVersion(workflowVersion);

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/SubWorkflow.java
@@ -55,9 +55,11 @@ public class SubWorkflow extends Task<SubWorkflow> {
         SubWorkflowParams subworkflowParam = workflowTask.getSubWorkflowParam();
         this.workflowName = subworkflowParam.getName();
         this.workflowVersion = subworkflowParam.getVersion();
-        if (subworkflowParam.getWorkflowDefinition() != null && subworkflowParam.getWorkflowDefinition() instanceof WorkflowDef) {
+        if (subworkflowParam.getWorkflowDefinition() != null
+                && subworkflowParam.getWorkflowDefinition() instanceof WorkflowDef) {
             this.conductorWorkflow =
-                    ConductorWorkflow.fromWorkflowDef((WorkflowDef) subworkflowParam.getWorkflowDefinition());
+                    ConductorWorkflow.fromWorkflowDef(
+                            (WorkflowDef) subworkflowParam.getWorkflowDefinition());
         }
     }
 

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
@@ -137,7 +137,7 @@ public class MockExternalPayloadStorage implements ExternalPayloadStorage {
             SubWorkflowParams subWorkflowParams = new SubWorkflowParams();
             subWorkflowParams.setName("one_task_workflow");
             subWorkflowParams.setVersion(1);
-            subWorkflowParams.setWorkflowDef(subWorkflowDef);
+            subWorkflowParams.setWorkflowDefinition(subWorkflowDef);
 
             WorkflowTask subWorkflowTask = new WorkflowTask();
             subWorkflowTask.setName("large_payload_subworkflow");


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Currently unsupported.
Issue [#1982 of parent OSS repo](https://github.com/Netflix/conductor/issues/1982)
This PR will allow setting subWorkflowParams like this:
```
"subWorkflowParam": {
        "workflowDefinition": "${workflow.input.tst}"
      }
```
so that parameter resolution will happen, and workflowDefinition, if available, will take priority over name.

Alternatives considered
----

The alternative was to keep everything in place, but alter SubWorkflowTaskMapper and SubWorkflow so that rname/version/definition resolution actually comes from task input instead of `subWorkflowParams`.
