### PR TITLE
(WIP) Bug Fix: Workflows with optional tasks in terminal state is left running

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -437,7 +437,7 @@ public class DeciderService {
             }
             // if we reach here, the task has been completed.
             // Was the task successful in completion?
-            if (!status.isSuccessful()) {
+            if (!status.isSuccessful() && !wftask.isOptional()) {
                 return false;
             }
         }

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -1241,6 +1241,55 @@ public class TestDeciderService {
         assertTrue(deciderService.checkForWorkflowCompletion(workflow));
     }
 
+    @Test
+    public void allOptionalTasksInTerminalStateShouldCompleteWf() {
+        var workflowDef = createAllOptionalTaskWorkflow();
+
+        var workflow = new WorkflowModel();
+        workflow.setWorkflowDefinition(workflowDef);
+        workflow.setStatus(WorkflowModel.Status.RUNNING);
+
+        // Workflow should be running
+        assertFalse(deciderService.checkForWorkflowCompletion(workflow));
+
+        var task1 = new TaskModel();
+        task1.setTaskType(SIMPLE.name());
+        task1.setReferenceTaskName("o1");
+        task1.setStatus(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR);
+
+        assertFalse(deciderService.checkForWorkflowCompletion(workflow));
+
+        var task2 = new TaskModel();
+        task2.setTaskType(SIMPLE.name());
+        task2.setReferenceTaskName("o2");
+        task2.setStatus(TaskModel.Status.COMPLETED_WITH_ERRORS);
+
+        workflow.getTasks().addAll(List.of(task1, task2));
+
+        // Workflow should be COMPLETED. All optional tasks have reached a terminal state.
+        assertTrue(deciderService.checkForWorkflowCompletion(workflow));
+    }
+
+    private WorkflowDef createAllOptionalTaskWorkflow() {
+        var workflowTask1 = new WorkflowTask();
+        workflowTask1.setName("junit_task_1");
+        workflowTask1.setTaskReferenceName("o1");
+        workflowTask1.setTaskDefinition(new TaskDef("junit_task_1"));
+        workflowTask1.setOptional(true);
+
+        var workflowTask2 = new WorkflowTask();
+        workflowTask2.setName("junit_task_2");
+        workflowTask2.setTaskReferenceName("o2");
+        workflowTask2.setTaskDefinition(new TaskDef("junit_task_2"));
+        workflowTask2.setOptional(true);
+
+        var workflowDef = new WorkflowDef();
+        workflowDef.setSchemaVersion(2);
+        workflowDef.setName("All Optional Tasks Workflow");
+        workflowDef.getTasks().addAll(Arrays.asList(workflowTask1, workflowTask2));
+        return workflowDef;
+    }
+
     private WorkflowDef createConditionalWF() {
 
         WorkflowTask workflowTask1 = new WorkflowTask();


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

This PR addresses an issue in the Decider's logic. If all task in a Workflow are optional and they have reached terminal state (failure or success doesn't matter) then the workflow should be considered complete.

E.g.: The following workflow is going to remain in `RUNNING` state despite having all of its tasks in a terminal state.

![image](https://github.com/orkes-io/conductor/assets/4755315/0f0fa3c7-6419-4d42-90c2-70a3533437cf)


