### PR TITLE
Fix path traversal in MockExternalPayloadStorage

### DIFF
--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorage.java
@@ -14,6 +14,8 @@ package com.netflix.conductor.test.utils;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,37 +68,73 @@ public class MockExternalPayloadStorage implements ExternalPayloadStorage {
         return location;
     }
 
+    /**
+     * Validates and resolves a file path to prevent directory traversal attacks.
+     *
+     * @param path the user-provided path
+     * @return a validated File object
+     * @throws SecurityException if the path attempts directory traversal
+     */
+    private File validateAndResolvePath(String path) throws IOException {
+        // Normalize the path to remove any ".." or "." components
+        Path normalized = Paths.get(path).normalize();
+
+        // Check if the normalized path contains ".." which would indicate traversal attempt
+        if (normalized.toString().contains("..")) {
+            throw new SecurityException("Path traversal not allowed: " + path);
+        }
+
+        // Create the file object
+        File file = new File(payloadDir, normalized.toString());
+
+        // Verify the canonical path is still within payloadDir
+        String canonicalPath = file.getCanonicalPath();
+        String canonicalBaseDir = payloadDir.getCanonicalPath();
+
+        if (!canonicalPath.startsWith(canonicalBaseDir + File.separator)
+                && !canonicalPath.equals(canonicalBaseDir)) {
+            throw new SecurityException("Access denied - path outside allowed directory: " + path);
+        }
+
+        return file;
+    }
+
     @Override
     public void upload(String path, InputStream payload, long payloadSize) {
-        File file = new File(payloadDir, path);
-        String filePath = file.getAbsolutePath();
         try {
-            if (!file.exists() && file.createNewFile()) {
-                LOGGER.debug("Created file: {}", filePath);
-            }
-            IOUtils.copy(payload, new FileOutputStream(file));
-            LOGGER.debug("Written to {}", filePath);
-        } catch (IOException e) {
-            // just handle this exception here and return empty map so that test will fail in case
-            // this exception is thrown
-            LOGGER.error("Error writing to {}", filePath);
-        } finally {
+            File file = validateAndResolvePath(path);
+            String filePath = file.getAbsolutePath();
             try {
-                if (payload != null) {
-                    payload.close();
+                if (!file.exists() && file.createNewFile()) {
+                    LOGGER.debug("Created file: {}", filePath);
                 }
+                IOUtils.copy(payload, new FileOutputStream(file));
+                LOGGER.debug("Written to {}", filePath);
             } catch (IOException e) {
-                LOGGER.warn("Unable to close input stream when writing to file");
+                // just handle this exception here and return empty map so that test will fail in
+                // case this exception is thrown
+                LOGGER.error("Error writing to {}", filePath);
+            } finally {
+                try {
+                    if (payload != null) {
+                        payload.close();
+                    }
+                } catch (IOException e) {
+                    LOGGER.warn("Unable to close input stream when writing to file");
+                }
             }
+        } catch (SecurityException | IOException e) {
+            LOGGER.error("Security validation failed for path: {}", path, e);
         }
     }
 
     @Override
     public InputStream download(String path) {
         try {
+            File file = validateAndResolvePath(path);
             LOGGER.debug("Reading from {}", path);
-            return new FileInputStream(new File(payloadDir, path));
-        } catch (IOException e) {
+            return new FileInputStream(file);
+        } catch (SecurityException | IOException e) {
             LOGGER.error("Error reading {}", path, e);
             return null;
         }

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorageTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/MockExternalPayloadStorageTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@ContextConfiguration(classes = {TestObjectMapperConfiguration.class})
+@RunWith(SpringRunner.class)
+public class MockExternalPayloadStorageTest {
+
+    private MockExternalPayloadStorage storage;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @Before
+    public void setup() throws IOException {
+        storage = new MockExternalPayloadStorage(objectMapper);
+    }
+
+    @Test
+    public void testNormalUploadAndDownload() {
+        // Test normal file upload and download
+        String validPath = "test-file.json";
+        String content = "test content";
+        InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        storage.upload(validPath, inputStream, content.length());
+
+        InputStream downloaded = storage.download(validPath);
+        assertNotNull("Should be able to download a valid file", downloaded);
+    }
+
+    @Test
+    public void testPathTraversalAttackWithDoubleDots() {
+        // Test that path traversal with "../" is blocked
+        String maliciousPath = "../../etc/passwd";
+        String content = "malicious content";
+        InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        // Upload should not throw exception but should fail silently (logged)
+        storage.upload(maliciousPath, inputStream, content.length());
+
+        // Download should return null for path traversal attempts
+        InputStream downloaded = storage.download(maliciousPath);
+        assertNull("Path traversal attack should be blocked", downloaded);
+    }
+
+    @Test
+    public void testPathTraversalAttackWithEncodedDots() {
+        // Test various path traversal patterns
+        String[] maliciousPaths = {
+            "../../../etc/passwd",
+            "foo/../../bar/../../../etc/passwd",
+            "./../../sensitive-file.txt"
+        };
+
+        for (String maliciousPath : maliciousPaths) {
+            InputStream downloaded = storage.download(maliciousPath);
+            assertNull(
+                    "Path traversal attack should be blocked for: " + maliciousPath,
+                    downloaded);
+        }
+    }
+
+    @Test
+    public void testValidNestedPath() {
+        // Test that valid nested paths still work
+        String validPath = "subdir/nested/file.json";
+        String content = "test content";
+        InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        storage.upload(validPath, inputStream, content.length());
+
+        InputStream downloaded = storage.download(validPath);
+        assertNotNull("Valid nested path should work", downloaded);
+    }
+
+    @Test
+    public void testPathWithDotInFilename() {
+        // Test that files with dots in the name (not path traversal) work fine
+        String validPath = "my.test.file.json";
+        String content = "test content";
+        InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        storage.upload(validPath, inputStream, content.length());
+
+        InputStream downloaded = storage.download(validPath);
+        assertNotNull("Files with dots in filename should work", downloaded);
+    }
+}


### PR DESCRIPTION
Resolves #706

## Summary

Fixes CodeQL path injection alert (#5) in `MockExternalPayloadStorage` by adding path validation to prevent directory traversal attacks like `../../etc/passwd`.

## Changes

- Added `validateAndResolvePath()` method that:
  - Normalizes paths using `Path.normalize()`
  - Rejects paths containing `..` components
  - Verifies canonical paths stay within `payloadDir`
- Updated `upload()` and `download()` to use validation
- Added comprehensive test coverage for attack scenarios

## Status of Other Alerts

The other two alerts from #706 are already resolved in the current codebase:
- **Alert #4** (DummyPayloadStorage): Fixed - now returns `null` instead of performing file operations
- **Alert #6** (ParametersUtils ReDoS): Fixed - vulnerable regex pattern removed, replaced with simpler `String.split()`

## Test Plan

- [x] Added `MockExternalPayloadStorageTest` with security test cases
- [x] Tests cover path traversal attempts, valid paths, and edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens file path handling in `MockExternalPayloadStorage` and adds targeted tests.
> 
> - Adds `validateAndResolvePath()` to normalize input, reject `..` components, and enforce canonical path stays within `payloadDir`
> - Updates `upload()` and `download()` to use validated paths and handle security exceptions
> - Introduces `MockExternalPayloadStorageTest` covering normal I/O, traversal attempts (`../`, nested variants), and valid nested/dotted filenames
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c38310a2a06884f631b349831f419026faf2014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->